### PR TITLE
Fix registry manifests: minEngineVersion, naming, schema cleanup

### DIFF
--- a/plugins/admin/manifest.json
+++ b/plugins/admin/manifest.json
@@ -15,8 +15,7 @@
     "moduleTypes": [],
     "stepTypes": [],
     "triggerTypes": [],
-    "workflowHandlers": [],
-    "wiringHooks": []
+    "workflowHandlers": []
   },
   "assets": {
     "ui": true,

--- a/plugins/ai/manifest.json
+++ b/plugins/ai/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["ai", "llm", "completion", "classification", "extraction", "dynamic", "hot-reload", "yaegi"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/api/manifest.json
+++ b/plugins/api/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["api", "rest", "cqrs", "gateway", "query", "command", "crud", "transformer"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/auth/manifest.json
+++ b/plugins/auth/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["auth", "jwt", "authentication", "users", "security", "token"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/authz/manifest.json
+++ b/plugins/authz/manifest.json
@@ -15,8 +15,7 @@
     "moduleTypes": ["authz.casbin"],
     "stepTypes": ["step.authz_check"],
     "triggerTypes": [],
-    "workflowHandlers": [],
-    "wiringHooks": []
+    "workflowHandlers": []
   },
   "assets": {
     "ui": false,

--- a/plugins/cicd/manifest.json
+++ b/plugins/cicd/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["cicd", "ci", "cd", "docker", "build", "deploy", "security", "scanning", "artifacts"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/cloud-ui/manifest.json
+++ b/plugins/cloud-ui/manifest.json
@@ -16,8 +16,7 @@
     "moduleTypes": ["static.fileserver"],
     "stepTypes": [],
     "triggerTypes": [],
-    "workflowHandlers": [],
-    "wiringHooks": []
+    "workflowHandlers": []
   },
   "assets": {
     "ui": true,

--- a/plugins/featureflags/manifest.json
+++ b/plugins/featureflags/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "feature-flags",
+  "name": "featureflags",
   "version": "1.0.0",
   "author": "GoCodeAlone",
   "description": "Feature flag service module and pipeline steps for runtime feature gating and gradual rollouts",
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["feature-flags", "flags", "toggles", "rollout", "gating", "sse"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/github/manifest.json
+++ b/plugins/github/manifest.json
@@ -15,8 +15,7 @@
     "moduleTypes": ["git.webhook"],
     "stepTypes": ["step.gh_action_trigger", "step.gh_action_status", "step.gh_create_check"],
     "triggerTypes": [],
-    "workflowHandlers": [],
-    "wiringHooks": []
+    "workflowHandlers": []
   },
   "assets": {
     "ui": false,

--- a/plugins/gitlab/manifest.json
+++ b/plugins/gitlab/manifest.json
@@ -20,8 +20,7 @@
       "step.gitlab_mr_comment"
     ],
     "triggerTypes": [],
-    "workflowHandlers": [],
-    "wiringHooks": []
+    "workflowHandlers": []
   },
   "assets": {
     "ui": false,

--- a/plugins/http/manifest.json
+++ b/plugins/http/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["http", "server", "router", "middleware", "proxy", "static", "cors", "ratelimit", "reverseproxy"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/integration/manifest.json
+++ b/plugins/integration/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["integration", "connectors", "multi-system", "webhook", "http", "etl"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/messaging/manifest.json
+++ b/plugins/messaging/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["messaging", "pubsub", "eventbus", "nats", "kafka", "slack", "webhook", "broker"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/modularcompat/manifest.json
+++ b/plugins/modularcompat/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["modular", "scheduler", "cache", "compatibility", "framework"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/observability/manifest.json
+++ b/plugins/observability/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["observability", "metrics", "prometheus", "health", "tracing", "otel", "openapi", "logging"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/pipelinesteps/manifest.json
+++ b/plugins/pipelinesteps/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["pipeline", "steps", "validate", "transform", "conditional", "jq", "http", "database", "json"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/platform/manifest.json
+++ b/plugins/platform/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["platform", "infrastructure", "iac", "provider", "resource", "reconciliation", "terraform"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/ratchet/manifest.json
+++ b/plugins/ratchet/manifest.json
@@ -8,7 +8,7 @@
   "type": "external",
   "tier": "community",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "homepage": "https://github.com/GoCodeAlone/ratchet",
   "repository": "https://github.com/GoCodeAlone/ratchet",
   "keywords": ["ai", "agent", "orchestration", "autonomous", "ratchet", "mcp", "llm", "sse", "vault", "secrets"],
@@ -54,5 +54,6 @@
       "ratchet.browser_manager",
       "ratchet.test_interaction"
     ]
-  }
+  },
+  "downloads": []
 }

--- a/plugins/scheduler/manifest.json
+++ b/plugins/scheduler/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["scheduler", "cron", "jobs", "schedule", "periodic", "timer"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/secrets/manifest.json
+++ b/plugins/secrets/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["secrets", "vault", "aws", "credentials", "security", "kms"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/statemachine/manifest.json
+++ b/plugins/statemachine/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["statemachine", "state", "transitions", "lifecycle", "workflow", "fsm"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",

--- a/plugins/storage/manifest.json
+++ b/plugins/storage/manifest.json
@@ -8,7 +8,7 @@
   "type": "builtin",
   "tier": "core",
   "license": "MIT",
-  "minEngineVersion": "0.1.0",
+  "minEngineVersion": "0.2.0",
   "keywords": ["storage", "s3", "gcs", "sqlite", "database", "persistence", "sql"],
   "homepage": "https://github.com/GoCodeAlone/workflow",
   "repository": "https://github.com/GoCodeAlone/workflow",


### PR DESCRIPTION
## Summary

- Fix `minEngineVersion` field values across plugin manifests to conform to schema constraints
- Normalize plugin naming conventions for consistency across registry entries
- Clean up schema violations and ensure all manifest.json files pass JSON validation

## Test plan

- [x] All `plugins/*/manifest.json` files pass `python3 -c "import json,sys; json.load(open(sys.argv[1]))"` validation
- [x] No JSON syntax errors detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)