### PR TITLE
feat(registry): add workflow-plugin-auth manifest + bump payments to v0.2.1

### DIFF
--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-payments",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "Multi-provider payment processing plugin (Stripe, PayPal)",
   "author": "GoCodeAlone",
   "license": "Apache-2.0",
@@ -41,22 +41,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.1.0/workflow-plugin-payments-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.1.0/workflow-plugin-payments-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.1.0/workflow-plugin-payments-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.1.0/workflow-plugin-payments-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/workflow-plugin-auth/manifest.json
+++ b/plugins/workflow-plugin-auth/manifest.json
@@ -1,0 +1,58 @@
+{
+  "name": "workflow-plugin-auth",
+  "version": "0.1.2",
+  "description": "Passwordless authentication plugin: WebAuthn/passkeys, TOTP, email magic links",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "core",
+  "private": true,
+  "minEngineVersion": "0.3.27",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-auth",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-auth",
+  "keywords": ["auth", "webauthn", "passkey", "totp", "magic-link", "passwordless"],
+  "capabilities": {
+    "moduleTypes": ["auth.credential"],
+    "stepTypes": [
+      "step.auth_passkey_begin_register",
+      "step.auth_passkey_finish_register",
+      "step.auth_passkey_begin_login",
+      "step.auth_passkey_finish_login",
+      "step.auth_totp_generate_secret",
+      "step.auth_totp_verify",
+      "step.auth_totp_recovery_codes",
+      "step.auth_magic_link_generate",
+      "step.auth_magic_link_verify",
+      "step.auth_magic_link_send",
+      "step.auth_credential_list",
+      "step.auth_credential_revoke"
+    ],
+    "triggerTypes": []
+  },
+  "assets": {
+    "ui": false,
+    "config": true
+  },
+  "downloads": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_linux_amd64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_linux_arm64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_darwin_amd64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_darwin_arm64.tar.gz"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Creates `plugins/workflow-plugin-auth/manifest.json` — external, private plugin (v0.1.2) with WebAuthn/TOTP/magic-link capabilities and download URLs for linux/darwin amd64/arm64
- Bumps `plugins/payments/manifest.json` from v0.1.0 → v0.2.1 with updated download URLs

## Why
- `wfctl plugin install workflow-plugin-auth` was resolving to the builtin `auth` manifest (no downloads array → error). The new manifest uses the full name `workflow-plugin-auth` to avoid that collision.
- Payments was pinned to a stale v0.1.0; latest release is v0.2.1 (2026-03-21).

## Verification
- Asset names confirmed via `gh release view` against both repos
- Both files validate as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)