### PR TITLE
feat(registry): bump digitalocean plugin to v0.3.1 with iac.provider moduleType

### DIFF
--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, IAM, and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -43,22 +43,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.1/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.1/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.1/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.1/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, IAM, and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -12,9 +12,28 @@
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
   "keywords": ["digitalocean", "iac", "infra", "kubernetes", "database", "app-platform", "spaces", "redis", "doks"],
   "capabilities": {
-    "moduleTypes": [],
+    "moduleTypes": ["iac.provider"],
     "stepTypes": [],
-    "triggerTypes": []
+    "triggerTypes": [],
+    "iacProvider": {
+      "name": "digitalocean",
+      "resourceTypes": [
+        "infra.container_service",
+        "infra.k8s_cluster",
+        "infra.database",
+        "infra.cache",
+        "infra.load_balancer",
+        "infra.vpc",
+        "infra.firewall",
+        "infra.dns",
+        "infra.storage",
+        "infra.registry",
+        "infra.certificate",
+        "infra.droplet",
+        "infra.iam_role",
+        "infra.api_gateway"
+      ]
+    }
   },
   "assets": {
     "ui": false,
@@ -24,22 +43,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.1.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.1.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.1.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.1.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.3.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -73,6 +73,23 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Post-init wiring hook names this plugin provides"
+        },
+        "iacProvider": {
+          "type": "object",
+          "description": "IaC provider declaration — name and supported resource types",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Canonical provider name used for discovery (e.g. \"digitalocean\", \"aws\", \"gcp\")"
+            },
+            "resourceTypes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Resource types this provider's drivers can manage (e.g. infra.container_service, infra.k8s_cluster)"
+            }
+          },
+          "required": ["name"],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- Bumps \`workflow-plugin-digitalocean\` manifest from v0.1.0 → v0.3.1
- Adds \`\"iac.provider\"\` to \`capabilities.moduleTypes\`
- Adds \`capabilities.iacProvider\` section with \`name: \"digitalocean\"\` and all 14 resource types, mirroring the upstream \`plugin.json\`
- Updates all 4 \`downloads[]\` URLs from \`v0.1.0\` → \`v0.3.1\`

## Version rationale

**v0.3.1 is correct.** v0.2.0 and v0.2.1 pre-existed Task 22. v0.3.0 was tagged but its release workflow was stuck on a self-hosted runner group that wasn't picking up jobs; team-lead patched \`release.yml\` to \`ubuntu-latest\` and re-tagged as v0.3.1.

## Asset name verification

✅ Verified — all 4 asset names confirmed via \`gh release view v0.3.1 --repo GoCodeAlone/workflow-plugin-digitalocean --json assets --jq '.assets[] | .name'\`:
\`\`\`
workflow-plugin-digitalocean-darwin-amd64.tar.gz
workflow-plugin-digitalocean-darwin-arm64.tar.gz
workflow-plugin-digitalocean-linux-amd64.tar.gz
workflow-plugin-digitalocean-linux-arm64.tar.gz
\`\`\`

## Test plan

- [x] \`python3 -c "import json; json.load(open('plugins/digitalocean/manifest.json'))"\` passes (JSON valid)
- [x] \`gh release view v0.3.1 --repo GoCodeAlone/workflow-plugin-digitalocean --json assets --jq '.assets[] | .name'\` confirms all 4 asset names match the URLs above
- [x] \`moduleTypes\` includes \`"iac.provider"\`
- [x] \`iacProvider.resourceTypes\` lists all 14 types from upstream plugin.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)