### PR TITLE
chore: bump auth→v0.1.3, payments→v0.2.2, digitalocean→v0.6.3

### DIFF
--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, IAM, and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -43,22 +43,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.1/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.1/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.1/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.1/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-payments",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Multi-provider payment processing plugin (Stripe, PayPal)",
   "author": "GoCodeAlone",
   "license": "Apache-2.0",
@@ -41,22 +41,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.1/workflow-plugin-payments-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/workflow-plugin-auth/manifest.json
+++ b/plugins/workflow-plugin-auth/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-auth",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Passwordless authentication plugin: WebAuthn/passkeys, TOTP, email magic links",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -37,22 +37,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_linux_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_linux_amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_linux_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_linux_arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_darwin_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_darwin_amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.2/workflow-plugin-auth_0.1.2_darwin_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_darwin_arm64.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Bump registry entries for three BMW-critical plugins after landing the dynamic-version refactor
- All three now inject `Manifest().Version` at build time via `-ldflags`, so engine-level `requires.plugins[].version` checks pass against real release tags
- Point all download URLs at the new tags

## Plugins bumped
| Plugin | Old | New |
|--------|-----|-----|
| workflow-plugin-auth | 0.1.2 | 0.1.3 |
| workflow-plugin-payments | 0.2.1 | 0.2.2 |
| workflow-plugin-digitalocean | 0.6.1 | 0.6.3 |

## Test plan
- [x] goreleaser builds tagged (v0.1.3, v0.2.2, v0.6.3) — binaries will embed injected Version
- [ ] BMW deploy picks up new manifests and passes `requires.plugins[].version` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)