### PR TITLE
chore: bump 31 plugins with dynamic ldflags Version

### DIFF
--- a/plugins/admin/manifest.json
+++ b/plugins/admin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "GoCodeAlone",
   "description": "Admin dashboard UI and config-driven admin routes with embedded React UI. Provides user management, workflow management, settings, and real-time monitoring.",
   "source": "github.com/GoCodeAlone/workflow-plugin-admin",
@@ -25,22 +25,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.0/workflow-plugin-admin-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.1/workflow-plugin-admin-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.0/workflow-plugin-admin-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.1/workflow-plugin-admin-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.0/workflow-plugin-admin-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.1/workflow-plugin-admin-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.0/workflow-plugin-admin-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.1/workflow-plugin-admin-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/approval/manifest.json
+++ b/plugins/approval/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-approval",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Human-in-the-loop approval workflows with state machine",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/audit/manifest.json
+++ b/plugins/audit/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-audit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Compliance audit logging with EventBus collection and S3/database sinks",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/authz-ui/manifest.json
+++ b/plugins/authz-ui/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "authz-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "GoCodeAlone",
   "description": "Casbin authorization policy management UI (React SPA)",
   "source": "github.com/GoCodeAlone/workflow-plugin-authz-ui",
@@ -26,22 +26,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.0/workflow-plugin-authz-ui-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.0/workflow-plugin-authz-ui-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.0/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.0/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/authz/manifest.json
+++ b/plugins/authz/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "authz",
-  "version": "0.3.0",
+  "version": "0.5.2",
   "author": "GoCodeAlone",
   "description": "RBAC authorization plugin using Casbin",
   "source": "github.com/GoCodeAlone/workflow-plugin-authz",
@@ -35,22 +35,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.3.0/workflow-plugin-authz-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.5.2/workflow-plugin-authz-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.3.0/workflow-plugin-authz-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.5.2/workflow-plugin-authz-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.3.0/workflow-plugin-authz-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.5.2/workflow-plugin-authz-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.3.0/workflow-plugin-authz-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.5.2/workflow-plugin-authz-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/aws/manifest.json
+++ b/plugins/aws/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-aws",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, and ACM resources",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -24,22 +24,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.0/workflow-plugin-aws-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.0/workflow-plugin-aws-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.0/workflow-plugin-aws-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.0/workflow-plugin-aws-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/azure/manifest.json
+++ b/plugins/azure/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-azure",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Microsoft Azure infrastructure provider: ACI, AKS, SQL, Redis, VNet, LB, DNS, ACR, APIM, NSG, MSI, Blob Storage, App Service Certificates",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -24,22 +24,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.0/workflow-plugin-azure-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.0/workflow-plugin-azure-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.0/workflow-plugin-azure-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.0/workflow-plugin-azure-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/bento/manifest.json
+++ b/plugins/bento/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "bento",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "author": "GoCodeAlone",
   "description": "Stream processing via Bento — 100+ connectors, Bloblang transforms, at-least-once delivery",
   "source": "github.com/GoCodeAlone/workflow-plugin-bento",
@@ -26,22 +26,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.0.0/workflow-plugin-bento-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.1.2/workflow-plugin-bento-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.0.0/workflow-plugin-bento-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.1.2/workflow-plugin-bento-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.0.0/workflow-plugin-bento-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.1.2/workflow-plugin-bento-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.0.0/workflow-plugin-bento-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.1.2/workflow-plugin-bento-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/ci-generator/manifest.json
+++ b/plugins/ci-generator/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-ci-generator",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "CI/CD config generator for GitHub Actions, GitLab CI, Jenkins, and CircleCI",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -26,22 +26,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.0/workflow-plugin-ci-generator-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.2/workflow-plugin-ci-generator-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.0/workflow-plugin-ci-generator-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.2/workflow-plugin-ci-generator-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.0/workflow-plugin-ci-generator-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.2/workflow-plugin-ci-generator-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.0/workflow-plugin-ci-generator-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.2/workflow-plugin-ci-generator-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/crm/manifest.json
+++ b/plugins/crm/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-crm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Vendor-neutral CRM integration with Salesforce adapter",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/data-engineering/manifest.json
+++ b/plugins/data-engineering/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "data-engineering",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "GoCodeAlone",
   "description": "Data engineering: CDC, lakehouse (Iceberg), time-series (InfluxDB/TimescaleDB/ClickHouse/QuestDB/Druid), graph (Neo4j), data quality, migrations, catalog (DataHub/OpenMetadata)",
   "source": "github.com/GoCodeAlone/workflow-plugin-data-engineering",
@@ -137,22 +137,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.0/workflow-plugin-data-engineering-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.1/workflow-plugin-data-engineering-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.0/workflow-plugin-data-engineering-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.1/workflow-plugin-data-engineering-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.0/workflow-plugin-data-engineering-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.1/workflow-plugin-data-engineering-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.0/workflow-plugin-data-engineering-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.1/workflow-plugin-data-engineering-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/datadog/manifest.json
+++ b/plugins/datadog/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-datadog",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Datadog monitoring and observability — metrics, events, monitors, dashboards, logs, synthetics, SLOs, incidents, and more",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -47,9 +47,9 @@
     "triggerTypes": []
   },
   "downloads": [
-    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.0/workflow-plugin-datadog-linux-amd64.tar.gz"},
-    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.0/workflow-plugin-datadog-linux-arm64.tar.gz"},
-    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.0/workflow-plugin-datadog-darwin-amd64.tar.gz"},
-    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.0/workflow-plugin-datadog-darwin-arm64.tar.gz"}
+    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.1/workflow-plugin-datadog-linux-amd64.tar.gz"},
+    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.1/workflow-plugin-datadog-linux-arm64.tar.gz"},
+    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.1/workflow-plugin-datadog-darwin-amd64.tar.gz"},
+    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.1/workflow-plugin-datadog-darwin-arm64.tar.gz"}
   ]
 }

--- a/plugins/discord/manifest.json
+++ b/plugins/discord/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "discord",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "GoCodeAlone",
   "description": "Discord messaging, bot automation, and voice channel support. Provides a provider module, pipeline steps for sending/editing/deleting messages and managing voice, and a WebSocket Gateway event trigger.",
   "source": "github.com/GoCodeAlone/workflow-plugin-discord",
@@ -32,22 +32,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.0/workflow-plugin-discord-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.1/workflow-plugin-discord-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.0/workflow-plugin-discord-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.1/workflow-plugin-discord-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.0/workflow-plugin-discord-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.1/workflow-plugin-discord-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.0/workflow-plugin-discord-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.1/workflow-plugin-discord-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/erp/manifest.json
+++ b/plugins/erp/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-erp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Enterprise ERP integration via OData v4 with SAP adapter",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-gcp",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -24,22 +24,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.0/workflow-plugin-gcp-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.0/workflow-plugin-gcp-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.0/workflow-plugin-gcp-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.0/workflow-plugin-gcp-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/github/manifest.json
+++ b/plugins/github/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "GoCodeAlone",
   "description": "GitHub integration plugin: webhook handling, GitHub Actions, PRs, issues, releases, and deployments",
   "source": "github.com/GoCodeAlone/workflow-plugin-github",
@@ -42,22 +42,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.1/workflow-plugin-github-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.2/workflow-plugin-github-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.1/workflow-plugin-github-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.2/workflow-plugin-github-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.1/workflow-plugin-github-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.2/workflow-plugin-github-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.1/workflow-plugin-github-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.2/workflow-plugin-github-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/gitlab/manifest.json
+++ b/plugins/gitlab/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "GoCodeAlone",
   "description": "GitLab integration — webhook handling and GitLab CI pipeline management",
   "source": "github.com/GoCodeAlone/workflow-plugin-gitlab",
@@ -30,22 +30,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.0/workflow-plugin-gitlab-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.1/workflow-plugin-gitlab-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.0/workflow-plugin-gitlab-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.1/workflow-plugin-gitlab-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.0/workflow-plugin-gitlab-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.1/workflow-plugin-gitlab-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.0/workflow-plugin-gitlab-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.0.1/workflow-plugin-gitlab-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/launchdarkly/manifest.json
+++ b/plugins/launchdarkly/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-launchdarkly",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "LaunchDarkly feature management — flags, segments, environments, projects, metrics, experiments, approvals, audit log, and more",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -48,9 +48,9 @@
     "triggerTypes": []
   },
   "downloads": [
-    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.0/workflow-plugin-launchdarkly-linux-amd64.tar.gz"},
-    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.0/workflow-plugin-launchdarkly-linux-arm64.tar.gz"},
-    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.0/workflow-plugin-launchdarkly-darwin-amd64.tar.gz"},
-    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.0/workflow-plugin-launchdarkly-darwin-arm64.tar.gz"}
+    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly-linux-amd64.tar.gz"},
+    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly-linux-arm64.tar.gz"},
+    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly-darwin-amd64.tar.gz"},
+    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly-darwin-arm64.tar.gz"}
   ]
 }

--- a/plugins/monday/manifest.json
+++ b/plugins/monday/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-monday",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Comprehensive monday.com integration — boards, items, columns, groups, workspaces, and all resources via GraphQL",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -78,22 +78,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.0/workflow-plugin-monday-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.0/workflow-plugin-monday-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.0/workflow-plugin-monday-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.0/workflow-plugin-monday-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/okta/manifest.json
+++ b/plugins/okta/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-okta",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "Okta identity and access management — users, groups, applications, authorization servers, MFA, policies, and more",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -43,9 +43,9 @@
     "triggerTypes": []
   },
   "downloads": [
-    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.1.0/workflow-plugin-okta-linux-amd64.tar.gz"},
-    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.1.0/workflow-plugin-okta-linux-arm64.tar.gz"},
-    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.1.0/workflow-plugin-okta-darwin-amd64.tar.gz"},
-    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.1.0/workflow-plugin-okta-darwin-arm64.tar.gz"}
+    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.1/workflow-plugin-okta-linux-amd64.tar.gz"},
+    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.1/workflow-plugin-okta-linux-arm64.tar.gz"},
+    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.1/workflow-plugin-okta-darwin-amd64.tar.gz"},
+    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.1/workflow-plugin-okta-darwin-arm64.tar.gz"}
   ]
 }

--- a/plugins/openlms/manifest.json
+++ b/plugins/openlms/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-openlms",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenLMS learning management — courses, enrollments, grades, assignments, quizzes, users, competencies, calendars, forums, and more",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -51,9 +51,9 @@
     "triggerTypes": []
   },
   "downloads": [
-    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.0/workflow-plugin-openlms-linux-amd64.tar.gz"},
-    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.0/workflow-plugin-openlms-linux-arm64.tar.gz"},
-    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.0/workflow-plugin-openlms-darwin-amd64.tar.gz"},
-    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.0/workflow-plugin-openlms-darwin-arm64.tar.gz"}
+    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-linux-amd64.tar.gz"},
+    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-linux-arm64.tar.gz"},
+    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-darwin-amd64.tar.gz"},
+    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-darwin-arm64.tar.gz"}
   ]
 }

--- a/plugins/salesforce/manifest.json
+++ b/plugins/salesforce/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-salesforce",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "Salesforce CRM — records, SOQL queries, bulk operations, approvals, flows, reports, dashboards, metadata, and more",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -41,9 +41,9 @@
     "triggerTypes": []
   },
   "downloads": [
-    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.1.0/workflow-plugin-salesforce-linux-amd64.tar.gz"},
-    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.1.0/workflow-plugin-salesforce-linux-arm64.tar.gz"},
-    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.1.0/workflow-plugin-salesforce-darwin-amd64.tar.gz"},
-    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.1.0/workflow-plugin-salesforce-darwin-arm64.tar.gz"}
+    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.2.1/workflow-plugin-salesforce-linux-amd64.tar.gz"},
+    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.2.1/workflow-plugin-salesforce-linux-arm64.tar.gz"},
+    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.2.1/workflow-plugin-salesforce-darwin-amd64.tar.gz"},
+    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.2.1/workflow-plugin-salesforce-darwin-arm64.tar.gz"}
   ]
 }

--- a/plugins/security/manifest.json
+++ b/plugins/security/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "security",
-  "version": "2.0.0",
+  "version": "0.2.2",
   "author": "GoCodeAlone",
   "description": "Unified security plugin: WAF (Coraza/AWS/GCloud/Cloudflare), MFA/encryption (TOTP, AES-256-GCM, AWS KMS, GCP KMS, Vault Transit), authorization (Casbin RBAC, Permit.io), data protection (PII detection/masking), sandbox (WASM/wazero, Docker), and supply-chain security (signatures, vuln scanning, SBOM)",
   "source": "github.com/GoCodeAlone/workflow-plugin-security",
@@ -83,22 +83,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.0/workflow-plugin-security-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.0/workflow-plugin-security-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.0/workflow-plugin-security-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.0/workflow-plugin-security-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/slack/manifest.json
+++ b/plugins/slack/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "slack",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "GoCodeAlone",
   "description": "Slack messaging and workspace automation. Provides a provider module backed by the Slack Web API and Socket Mode, pipeline steps for messages/blocks/reactions/files, and a Socket Mode event trigger.",
   "source": "github.com/GoCodeAlone/workflow-plugin-slack",
@@ -30,22 +30,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.0/workflow-plugin-slack-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.0/workflow-plugin-slack-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.0/workflow-plugin-slack-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.0/workflow-plugin-slack-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.1/workflow-plugin-slack-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/sso/manifest.json
+++ b/plugins/sso/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-sso",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Enterprise SSO via OpenID Connect with multi-provider support",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/teams/manifest.json
+++ b/plugins/teams/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "teams",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "author": "GoCodeAlone",
   "description": "Microsoft Teams messaging and channel management via the Microsoft Graph API. Provides a provider module with Azure AD client credentials auth, pipeline steps for messages/cards/channels/members, and an HTTP webhook trigger for Graph change notifications.",
   "source": "github.com/GoCodeAlone/workflow-plugin-teams",
@@ -29,22 +29,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.0/workflow-plugin-teams-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.2/workflow-plugin-teams-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.0/workflow-plugin-teams-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.2/workflow-plugin-teams-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.0/workflow-plugin-teams-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.2/workflow-plugin-teams-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.0/workflow-plugin-teams-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.2/workflow-plugin-teams-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/tofu/manifest.json
+++ b/plugins/tofu/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-tofu",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "OpenTofu/Terraform adapter: HCL generation from abstract infra specs, plan/apply execution, and state import/export",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -31,22 +31,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.0/workflow-plugin-tofu-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.2/workflow-plugin-tofu-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.0/workflow-plugin-tofu-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.2/workflow-plugin-tofu-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.0/workflow-plugin-tofu-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.2/workflow-plugin-tofu-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.0/workflow-plugin-tofu-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.2/workflow-plugin-tofu-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/turnio/manifest.json
+++ b/plugins/turnio/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-turnio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "turn.io WhatsApp API integration — messaging, contacts, templates, flows, and journeys",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -46,22 +46,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.0/workflow-plugin-turnio-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.1/workflow-plugin-turnio-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.0/workflow-plugin-turnio-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.1/workflow-plugin-turnio-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.0/workflow-plugin-turnio-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.1/workflow-plugin-turnio-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.0/workflow-plugin-turnio-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.1/workflow-plugin-turnio-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/twilio/manifest.json
+++ b/plugins/twilio/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-twilio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Comprehensive Twilio integration — SMS, Voice, Verify, Video, Conversations, TaskRouter, and 40+ products",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -114,22 +114,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.0/workflow-plugin-twilio-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.0/workflow-plugin-twilio-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.0/workflow-plugin-twilio-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.0/workflow-plugin-twilio-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/vectorstore/manifest.json
+++ b/plugins/vectorstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-vectorstore",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Vector database integration for RAG pipelines with Pinecone support",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/websocket/manifest.json
+++ b/plugins/websocket/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-websocket",
-  "version": "0.1.0",
+  "version": "0.5.3",
   "author": "GoCodeAlone",
   "description": "General-purpose WebSocket support — rooms, broadcast, send, close",
   "source": "github.com/GoCodeAlone/workflow-plugin-websocket",


### PR DESCRIPTION
## Summary

Priority 2 + Priority 3 version-injection sweep. Every plugin below now has its `Manifest().Version` injected at build time via `-ldflags -X` instead of a hardcoded string, plus a sed before-hook so `plugin.json` is bumped at release time. This unblocks the workflow engine's `requires.plugins[].version` check for anything referencing these plugins.

## Plugins bumped

31 plugins; full list in commit message. Every entry points at the new release tag and URL.

## Test plan

- [x] Each plugin binary verified to contain the injected Version string (ldflags sanity check in pattern script)
- [x] `go build ./...` and `go test ./...` pass per plugin (with noted pre-existing exceptions logged separately)
- [x] JSON Schema validation on registry manifests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)