### PR TITLE
chore: follow-up bumps for goreleaser-fix plugins

### DIFF
--- a/plugins/authz-ui/manifest.json
+++ b/plugins/authz-ui/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "authz-ui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "GoCodeAlone",
   "description": "Casbin authorization policy management UI (React SPA)",
   "source": "github.com/GoCodeAlone/workflow-plugin-authz-ui",
@@ -26,22 +26,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.1/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-gcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -24,22 +24,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.2/workflow-plugin-gcp-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/monday/manifest.json
+++ b/plugins/monday/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-monday",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Comprehensive monday.com integration — boards, items, columns, groups, workspaces, and all resources via GraphQL",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -78,22 +78,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.2/workflow-plugin-monday-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.2/workflow-plugin-monday-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.2/workflow-plugin-monday-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.1/workflow-plugin-monday-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.2/workflow-plugin-monday-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/openlms/manifest.json
+++ b/plugins/openlms/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-openlms",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenLMS learning management — courses, enrollments, grades, assignments, quizzes, users, competencies, calendars, forums, and more",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -51,9 +51,9 @@
     "triggerTypes": []
   },
   "downloads": [
-    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-linux-amd64.tar.gz"},
-    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-linux-arm64.tar.gz"},
-    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-darwin-amd64.tar.gz"},
-    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.1/workflow-plugin-openlms-darwin-arm64.tar.gz"}
+    {"os": "linux", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.2/workflow-plugin-openlms-linux-amd64.tar.gz"},
+    {"os": "linux", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.2/workflow-plugin-openlms-linux-arm64.tar.gz"},
+    {"os": "darwin", "arch": "amd64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.2/workflow-plugin-openlms-darwin-amd64.tar.gz"},
+    {"os": "darwin", "arch": "arm64", "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.2/workflow-plugin-openlms-darwin-arm64.tar.gz"}
   ]
 }

--- a/plugins/twilio/manifest.json
+++ b/plugins/twilio/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-twilio",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Comprehensive Twilio integration — SMS, Voice, Verify, Video, Conversations, TaskRouter, and 40+ products",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -114,22 +114,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.1/workflow-plugin-twilio-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/websocket/manifest.json
+++ b/plugins/websocket/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-websocket",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": "GoCodeAlone",
   "description": "General-purpose WebSocket support — rooms, broadcast, send, close",
   "source": "github.com/GoCodeAlone/workflow-plugin-websocket",


### PR DESCRIPTION
## Summary

Follow-up to #16. These 6 plugins' release pipelines failed (unrelated
to the Version-injection refactor) due to pre-existing goreleaser
config bugs. Each has been fixed and re-tagged.

| Plugin | Old | New | Fix |
|---|---|---|---|
| authz-ui | 0.1.1 | 0.1.2 | merged duplicate before: block |
| gcp | 0.1.2 | 0.1.3 | setup-go 1.22 -> 1.26 |
| monday | 0.1.1 | 0.1.2 | removed top-level after: block |
| openlms | 0.1.1 | 0.1.2 | removed top-level after: block |
| twilio | 0.1.1 | 0.1.2 | removed top-level after: block |
| websocket | 0.5.3 | 0.5.4 | removed orphan sed hook (no plugin.json) |

## Test plan

- [x] Each repo's release workflow re-triggered by new tag
- [ ] Verify published binaries contain injected Version

🤖 Generated with [Claude Code](https://claude.com/claude-code)