### PR TITLE
chore: bump digitalocean plugin to v0.7.0 with supportedCanonicalKeys

### DIFF
--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, IAM, and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -32,6 +32,40 @@
         "infra.droplet",
         "infra.iam_role",
         "infra.api_gateway"
+      ],
+      "supportedCanonicalKeys": [
+        "name",
+        "region",
+        "image",
+        "http_port",
+        "instance_count",
+        "size",
+        "env_vars",
+        "env_vars_secret",
+        "autoscaling",
+        "routes",
+        "health_check",
+        "liveness_check",
+        "cors",
+        "protocol",
+        "internal_ports",
+        "build_command",
+        "run_command",
+        "dockerfile_path",
+        "source_dir",
+        "termination",
+        "domains",
+        "alerts",
+        "log_destinations",
+        "ingress",
+        "egress",
+        "maintenance",
+        "vpc_ref",
+        "jobs",
+        "workers",
+        "static_sites",
+        "sidecars",
+        "provider_specific"
       ]
     }
   },
@@ -43,22 +77,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.6.3/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -86,6 +86,11 @@
               "type": "array",
               "items": { "type": "string" },
               "description": "Resource types this provider's drivers can manage (e.g. infra.container_service, infra.k8s_cluster)"
+            },
+            "supportedCanonicalKeys": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Canonical config keys this provider's drivers can map (e.g. name, region, image, env_vars)"
             }
           },
           "required": ["name"],


### PR DESCRIPTION
## Summary

- Bumps `workflow-plugin-digitalocean` from v0.6.3 → v0.7.0
- Updates all 4 download URLs to the v0.7.0 release assets
- Adds `supportedCanonicalKeys` array (all 32 canonical keys) to the `iacProvider` capability block:
  - **sidecars** — mapped as sibling `AppServiceSpec` entries in App Platform
  - **protocol** — via `servingProtocolFromConfig` in app platform buildspec
  - **trusted_sources** — wired in `DatabaseDriver` (create firewall rules + update firewall sync with key-presence sentinel)
  - All other keys were already mapped; `doUnsupportedCanonicalKeys` is now empty

## Test plan

- [ ] Verify manifest JSON is valid (no parse errors)
- [ ] Confirm v0.7.0 release assets exist at the listed URLs on GitHub
- [ ] Confirm all 32 keys match `DOProvider.SupportedCanonicalKeys()` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)