### PR TITLE
feat(schema): add migrationDrivers, cliCommands, buildHooks to capabilities

### DIFF
--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -95,6 +95,73 @@
           },
           "required": ["name"],
           "additionalProperties": false
+        },
+        "migrationDrivers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Migration driver names this plugin provides (e.g. golang-migrate, goose)"
+        },
+        "cliCommands": {
+          "type": "array",
+          "description": "Dynamic wfctl CLI subcommand registrations (workflow v0.18.x+)",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Top-level command name registered with wfctl"
+              },
+              "description": {
+                "type": "string"
+              },
+              "flags_passthrough": {
+                "type": "boolean",
+                "description": "When true, wfctl passes all flags through to the plugin binary"
+              },
+              "subcommands": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "buildHooks": {
+          "type": "array",
+          "description": "Build-pipeline hook registrations (workflow v0.18.x+)",
+          "items": {
+            "type": "object",
+            "required": ["event", "priority"],
+            "properties": {
+              "event": {
+                "type": "string",
+                "description": "Hook event name (e.g. post_container_build, install_verify)"
+              },
+              "priority": {
+                "type": "integer",
+                "description": "Execution priority; lower numbers run first"
+              },
+              "on_hook_failure": {
+                "type": "string",
+                "enum": ["fail", "warn", "skip"],
+                "description": "How wfctl handles hook failures"
+              },
+              "description": {
+                "type": "string",
+                "description": "Human-readable description of what this hook does"
+              }
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- Extends `capabilities` schema to match workflow-cloud-registry + support workflow v0.18.x plugin metadata declarations (build hooks, dynamic CLI, migration drivers)
- Unblocks workflow-plugin-migrations + future DO/supply-chain plugin re-declarations in the public registry
- All three fields are optional; all existing manifests continue to validate clean

## Fields added to `capabilities`

| Field | Type | Description |
|---|---|---|
| `migrationDrivers` | `string[]` | Migration driver names a plugin provides (e.g. `golang-migrate`, `goose`) |
| `cliCommands` | `object[]` | Dynamic wfctl CLI subcommand registrations — matches cloud-registry shape exactly |
| `buildHooks` | `object[]` | Build-pipeline hook registrations — matches cloud-registry shape exactly |

## Test plan

- [x] `scripts/validate-manifests.sh` passes locally — all existing manifests valid
- [x] JSON schema is well-formed (`python3 -m json.tool`)
- [ ] CI validate-manifests check passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)