### PR TITLE
chore: bump auth and twilio plugin manifests

### DIFF
--- a/plugins/twilio/manifest.json
+++ b/plugins/twilio/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-twilio",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Comprehensive Twilio integration — SMS, Voice, Verify, Video, Conversations, TaskRouter, and 40+ products",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -114,22 +114,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.3/workflow-plugin-twilio-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.3/workflow-plugin-twilio-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.3/workflow-plugin-twilio-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.2/workflow-plugin-twilio-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.1.3/workflow-plugin-twilio-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/workflow-plugin-auth/manifest.json
+++ b/plugins/workflow-plugin-auth/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-auth",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Passwordless authentication plugin: WebAuthn/passkeys, TOTP, email magic links",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -37,22 +37,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_linux_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_linux_amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_linux_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_linux_arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_darwin_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_darwin_amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.3/workflow-plugin-auth_0.1.3_darwin_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_darwin_arm64.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
Updates registry manifests for releases needed by BMW passwordless auth work.\n\n- workflow-plugin-auth: 0.1.3 -> 0.1.4\n- workflow-plugin-twilio: 0.1.2 -> 0.1.3\n- Updates all release asset URLs to the published artifacts\n\nVerification:\n- jq empty plugins/workflow-plugin-auth/manifest.json plugins/twilio/manifest.json\n- bash scripts/validate-manifests.sh\n\nNote: scripts/validate-templates.sh is currently blocked locally on macOS by grep -P portability, unrelated to these manifest changes.