### PR TITLE
chore(registry): bump workflow-plugin-digitalocean to v0.9.0

### DIFF
--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.7.0",
-  "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, IAM, and API gateway",
+  "version": "0.9.0",
+  "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage Volumes, IAM, and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",
@@ -10,7 +10,7 @@
   "minEngineVersion": "0.3.51",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
-  "keywords": ["digitalocean", "iac", "infra", "kubernetes", "database", "app-platform", "spaces", "redis", "doks"],
+  "keywords": ["digitalocean", "iac", "infra", "kubernetes", "database", "app-platform", "spaces", "redis", "doks", "block-storage"],
   "capabilities": {
     "moduleTypes": ["iac.provider"],
     "stepTypes": [],
@@ -30,6 +30,7 @@
         "infra.registry",
         "infra.certificate",
         "infra.droplet",
+        "infra.volume",
         "infra.iam_role",
         "infra.api_gateway"
       ],
@@ -40,6 +41,7 @@
         "http_port",
         "instance_count",
         "size",
+        "size_gb",
         "env_vars",
         "env_vars_secret",
         "autoscaling",
@@ -61,6 +63,16 @@
         "egress",
         "maintenance",
         "vpc_ref",
+        "vpc_uuid",
+        "user_data",
+        "ssh_keys",
+        "tags",
+        "enable_backups",
+        "monitoring",
+        "ipv6",
+        "volumes",
+        "filesystem_type",
+        "description",
         "jobs",
         "workers",
         "static_sites",
@@ -77,22 +89,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.7.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bump `workflow-plugin-digitalocean` to **v0.9.0** with the new resource type and extended Droplet config keys.

## v0.9.0 highlights
- **New `infra.volume`** — DO Block Storage driver (CRUD + in-place resize on growth + ForceNew on shrink + name↔ID resolution)
- **Extended `infra.droplet`** config: `user_data`, `vpc_uuid`, `ssh_keys` (mixed fingerprint+int ID), `tags`, `enable_backups`, `monitoring`, `ipv6`, `volumes` (by name)
- **Droplet output** gains `private_ip`
- Hardened Diff coverage for description/tags/vpc_uuid/backups drift (3 review rounds, 22 hardening commits)

## Driving use case

`core-dump` is replacing DO Managed Postgres with a self-hosted apache/age Droplet because DO Managed PG doesn't support the Apache AGE extension. This registry bump unblocks that downstream change.

## Manifest changes
- `version`: 0.7.0 → 0.9.0
- `description` mentions Block Storage volumes
- `keywords` adds `block-storage`
- `resourceTypes` adds `infra.volume`
- `supportedCanonicalKeys` adds: `size_gb`, `vpc_uuid`, `user_data`, `ssh_keys`, `tags`, `enable_backups`, `monitoring`, `ipv6`, `volumes`, `filesystem_type`, `description`
- `downloads.url` paths bump v0.7.0 → v0.9.0

## Test plan
- [ ] CI green
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)