### PR TITLE
plugins: register audit-chain + eventbus (BMW pilot prereq)

### DIFF
--- a/plugins/audit-chain/manifest.json
+++ b/plugins/audit-chain/manifest.json
@@ -1,0 +1,67 @@
+{
+    "name": "workflow-plugin-audit-chain",
+    "version": "0.1.0",
+    "description": "Tamper-evident hash-chained audit logging with periodic Merkle root anchoring (OpenTimestamps/Bitcoin, git, Sigstore)",
+    "author": "GoCodeAlone",
+    "license": "MIT",
+    "type": "external",
+    "tier": "community",
+    "private": false,
+    "minEngineVersion": "0.20.0",
+    "keywords": [
+        "audit",
+        "hash-chain",
+        "merkle",
+        "opentimestamps",
+        "tamper-evident"
+    ],
+    "homepage": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain",
+    "repository": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain",
+    "capabilities": {
+        "moduleTypes": [
+            "audit.ledger",
+            "audit.anchor_provider.opentimestamps",
+            "audit.anchor_provider.git",
+            "audit.anchor_provider.sigstore"
+        ],
+        "stepTypes": [
+            "step.audit.append",
+            "step.audit.verify",
+            "step.audit.merkle_root",
+            "step.audit.anchor",
+            "step.audit.poll_anchor_confirmation",
+            "step.audit.proof",
+            "step.audit.public_receipt"
+        ],
+        "triggerTypes": [
+            "trigger.audit.entry_appended"
+        ]
+    },
+    "downloads": [
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain/releases/download/v0.1.0/workflow-plugin-audit-chain-linux-amd64.tar.gz"
+        },
+        {
+            "os": "linux",
+            "arch": "arm64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain/releases/download/v0.1.0/workflow-plugin-audit-chain-linux-arm64.tar.gz"
+        },
+        {
+            "os": "darwin",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain/releases/download/v0.1.0/workflow-plugin-audit-chain-darwin-amd64.tar.gz"
+        },
+        {
+            "os": "darwin",
+            "arch": "arm64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain/releases/download/v0.1.0/workflow-plugin-audit-chain-darwin-arm64.tar.gz"
+        },
+        {
+            "os": "windows",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain/releases/download/v0.1.0/workflow-plugin-audit-chain-windows-amd64.tar.gz"
+        }
+    ]
+}

--- a/plugins/eventbus/manifest.json
+++ b/plugins/eventbus/manifest.json
@@ -1,0 +1,64 @@
+{
+    "name": "workflow-plugin-eventbus",
+    "version": "0.1.0",
+    "description": "Provisions durable event-bus clusters (NATS / Kafka / Kinesis) as IaC and exposes typed pipeline steps for publish / consume operations.",
+    "author": "GoCodeAlone",
+    "license": "MIT",
+    "type": "external",
+    "tier": "community",
+    "private": false,
+    "minEngineVersion": "0.20.0",
+    "keywords": [
+        "eventbus",
+        "nats",
+        "kafka",
+        "kinesis",
+        "iac",
+        "infra",
+        "jetstream"
+    ],
+    "homepage": "https://github.com/GoCodeAlone/workflow-plugin-eventbus",
+    "repository": "https://github.com/GoCodeAlone/workflow-plugin-eventbus",
+    "capabilities": {
+        "moduleTypes": [
+            "infra.eventbus",
+            "infra.eventbus.stream",
+            "infra.eventbus.consumer"
+        ],
+        "stepTypes": [
+            "step.eventbus.publish",
+            "step.eventbus.consume",
+            "step.eventbus.ack"
+        ],
+        "triggerTypes": [
+            "trigger.eventbus.subscribe"
+        ]
+    },
+    "downloads": [
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-linux-amd64.tar.gz"
+        },
+        {
+            "os": "linux",
+            "arch": "arm64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-linux-arm64.tar.gz"
+        },
+        {
+            "os": "darwin",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-darwin-amd64.tar.gz"
+        },
+        {
+            "os": "darwin",
+            "arch": "arm64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-darwin-arm64.tar.gz"
+        },
+        {
+            "os": "windows",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-windows-amd64.tar.gz"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Adds registry manifests for two plugins that shipped v0.1.0 but were never registered:

- **audit-chain** — `workflow-plugin-audit-chain` (BMW pilot PRs 1-4)
- **eventbus** — `workflow-plugin-eventbus` (BMW pilot PRs 5-7)

Required for BMW PR 11 image-launch CI to install them via setup-plugins (currently 404 at `https://gocodealone.github.io/workflow-registry/v1/plugins/audit-chain/manifest.json`).

Manifests sourced from each plugin repo's source `plugin.json`, with two source-only fields stripped that the registry schema doesn't allow:
- \`contracts\` (plugin.json's strict-proto descriptors — those live in plugin.contracts.json on the source side)
- \`capabilities.configProvider\` (boolean flag not in the registry schema)

Both pass \`bash scripts/validate-manifests.sh\` locally.

## Test plan
- [x] \`scripts/validate-manifests.sh\` passes
- [x] Both releases exist on GitHub (v0.1.0 of each plugin repo) — download URLs in manifests are valid