### PR TITLE
fix(payments): bump manifest to v0.3.1 + add cliCommands + new step type

### DIFF
--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -36,8 +36,7 @@
     "cliCommands": [
       {
         "name": "payments",
-        "description": "Payment provider operations (webhook ensure, …)",
-        "flagsPassthrough": true
+        "description": "Payment provider operations (webhook ensure, …)"
       }
     ]
   },

--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-payments",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "description": "Multi-provider payment processing plugin (Stripe, PayPal)",
   "author": "GoCodeAlone",
   "license": "Apache-2.0",
@@ -24,6 +24,7 @@
       "step.payment_checkout_create",
       "step.payment_portal_create",
       "step.payment_webhook_verify",
+      "step.payment_webhook_endpoint_ensure",
       "step.payment_transfer",
       "step.payment_payout",
       "step.payment_fee_calculate",
@@ -31,7 +32,14 @@
       "step.payment_method_attach",
       "step.payment_method_list"
     ],
-    "triggerTypes": []
+    "triggerTypes": [],
+    "cliCommands": [
+      {
+        "name": "payments",
+        "description": "Payment provider operations (webhook ensure, …)",
+        "flagsPassthrough": true
+      }
+    ]
   },
   "assets": {
     "ui": false,
@@ -41,22 +49,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.3.1/workflow-plugin-payments-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.3.1/workflow-plugin-payments-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.3.1/workflow-plugin-payments-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.2.2/workflow-plugin-payments-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.3.1/workflow-plugin-payments-darwin-arm64.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
## Summary

\`wfctl plugin install\` overwrites the bundled \`plugin.json\` with this registry manifest. The previous v0.2.2 entry lacks the \`capabilities.cliCommands\` field added in workflow-plugin-payments v0.3.1, so \`wfctl payments\` fails with \`unknown command: payments\` on every install.

## Diagnostic

Confirmed via BMW debug run [25622418763](https://github.com/GoCodeAlone/buymywishlist/actions/runs/25622418763):

| Source | plugin.json size | \`capabilities.cliCommands\` |
|---|---|---|
| Release tarball (workflow-plugin-payments v0.3.1) | 27 KB | ✅ \`[{name: payments, …}]\` |
| Runner after \`wfctl plugin install\` | **1 KB** | ❌ missing |

The 1 KB file is THIS registry manifest (stamped to plugin.json by \`wfctl plugin install\`).

## Changes

- \`version\`: 0.2.2 → 0.3.1 (sync with latest release)
- \`capabilities.stepTypes\` += \`step.payment_webhook_endpoint_ensure\` (new in v0.3.0)
- \`capabilities.cliCommands\` += \`{name: payments, description, flagsPassthrough: true}\`
- \`downloads.url\` paths bumped to v0.3.1 release artifacts

## Test plan

- [ ] Merge → BMW \`provision-stripe-issuing-webhook\` workflow re-runs cleanly with \`wfctl payments webhook ensure …\`
- [ ] \`STRIPE_ISSUING_WEBHOOK_SECRET_STAGING\` lands in repo-level secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)