### PR TITLE
chore(digitalocean): bump manifest v0.9.2 → v1.0.1

### DIFF
--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,13 +1,13 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.9.2",
+  "version": "1.0.1",
+  "minEngineVersion": "0.51.0",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage Volumes, IAM, and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",
   "tier": "community",
   "private": false,
-  "minEngineVersion": "0.3.51",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
   "keywords": ["digitalocean", "iac", "infra", "kubernetes", "database", "app-platform", "spaces", "redis", "doks", "block-storage"],
@@ -89,22 +89,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.2/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.1/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.2/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.1/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.2/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.1/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.9.2/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.1/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Bump `plugins/digitalocean/manifest.json` from v0.9.2 → v1.0.1
- Bump `minEngineVersion` to 0.51.0 (PluginService bridge in workflow PR 623)
- Updates all 4 download URLs to v1.0.1 release artifacts

## Why
DO plugin v1.0.1 ships the strict-contracts force-cutover typed surface (pb.IaCProviderRequiredServer + 6 optionals + ResourceDriverServer; canonical_keys + compute_plan_version on capabilities). Lockfile pin alone is insufficient — `wfctl plugin install` gates against registry manifest, refusing to install v1.0.1 while manifest is at v0.9.2.

Core-dump strict-contracts smoke run 25642255188 surfaced this:
> error installing workflow-plugin-digitalocean: requested version v1.0.1 not available for "digitalocean" (registry manifest is at 0.9.2)

## Test plan
- [x] `jq .` parses
- [ ] Validate Registry CI passes
- [ ] Smoke re-dispatch (core-dump strict-contracts-smoke.yml) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)