### PR TITLE
chore(eventbus): bump manifest to v0.2.0 with renamed module types

### DIFF
--- a/plugins/eventbus/manifest.json
+++ b/plugins/eventbus/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-eventbus",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Provisions durable event-bus clusters (NATS / Kafka / Kinesis) as IaC and exposes typed pipeline steps for publish / consume operations.",
     "author": "GoCodeAlone",
     "license": "MIT",
@@ -21,9 +21,9 @@
     "repository": "https://github.com/GoCodeAlone/workflow-plugin-eventbus",
     "capabilities": {
         "moduleTypes": [
-            "infra.eventbus",
-            "infra.eventbus.stream",
-            "infra.eventbus.consumer"
+            "eventbus.broker",
+            "eventbus.stream",
+            "eventbus.consumer"
         ],
         "stepTypes": [
             "step.eventbus.publish",
@@ -38,27 +38,27 @@
         {
             "os": "linux",
             "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-linux-amd64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.2.0/workflow-plugin-eventbus-linux-amd64.tar.gz"
         },
         {
             "os": "linux",
             "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-linux-arm64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.2.0/workflow-plugin-eventbus-linux-arm64.tar.gz"
         },
         {
             "os": "darwin",
             "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-darwin-amd64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.2.0/workflow-plugin-eventbus-darwin-amd64.tar.gz"
         },
         {
             "os": "darwin",
             "arch": "arm64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-darwin-arm64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.2.0/workflow-plugin-eventbus-darwin-arm64.tar.gz"
         },
         {
             "os": "windows",
             "arch": "amd64",
-            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.1.0/workflow-plugin-eventbus-windows-amd64.tar.gz"
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.2.0/workflow-plugin-eventbus-windows-amd64.tar.gz"
         }
     ]
 }


### PR DESCRIPTION
## Why

workflow-plugin-eventbus v0.2.0 ships with breaking module type rename + new pgchannel provider + RuntimeBroker abstraction. Plugin PR: https://github.com/GoCodeAlone/workflow-plugin-eventbus/pull/6.

## What

- \`version\` 0.1.0 → 0.2.0
- \`moduleTypes\` renamed:
  - \`infra.eventbus\` → \`eventbus.broker\`
  - \`infra.eventbus.stream\` → \`eventbus.stream\`
  - \`infra.eventbus.consumer\` → \`eventbus.consumer\`
- Download URLs point at \`v0.2.0\` release artifacts
- All 5 supported platforms (linux/darwin amd64+arm64 + windows amd64) bumped

## Sequence

Merge order:
1. workflow-plugin-eventbus PR #6 merges → tag v0.2.0 cut → release artifacts published
2. **This PR** lands → registry advertises v0.2.0 + new types
3. Consumer projects (e.g. buymywishlist) bump their \`.wfctl-lock.yaml\` pin

This PR must NOT merge before the v0.2.0 tag exists (registry strict-contracts gate will fail on missing artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)