### PR TITLE
chore: sync plugin version manifests to latest tags

### DIFF
--- a/plugins/admin/manifest.json
+++ b/plugins/admin/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "author": "GoCodeAlone",
   "description": "Admin dashboard UI and config-driven admin routes with embedded React UI. Provides user management, workflow management, settings, and real-time monitoring.",
   "source": "github.com/GoCodeAlone/workflow-plugin-admin",

--- a/plugins/agent/manifest.json
+++ b/plugins/agent/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "agent",
-  "version": "0.5.2",
+  "version": "0.9.2",
   "author": "GoCodeAlone",
   "description": "AI agent primitives for workflow apps — provider abstraction, execution loop, tool registry, memory, loop detection, orchestration (SSE hub, scheduler, MCP client/server, approvals, sub-agents, webhooks, security auditing, JWT, bcrypt, OAuth)",
   "source": "github.com/GoCodeAlone/workflow-plugin-agent",

--- a/plugins/approval/manifest.json
+++ b/plugins/approval/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-approval",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Human-in-the-loop approval workflows with state machine",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/authz/manifest.json
+++ b/plugins/authz/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "authz",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": "GoCodeAlone",
   "description": "RBAC authorization plugin using Casbin",
   "source": "github.com/GoCodeAlone/workflow-plugin-authz",

--- a/plugins/ci-generator/manifest.json
+++ b/plugins/ci-generator/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-ci-generator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "CI/CD config generator for GitHub Actions, GitLab CI, Jenkins, and CircleCI",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "1.0.7",
+  "version": "1.0.12",
   "minEngineVersion": "0.51.0",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage Volumes, IAM, and API gateway",
   "author": "GoCodeAlone",

--- a/plugins/github/manifest.json
+++ b/plugins/github/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "GoCodeAlone",
   "description": "GitHub integration plugin: webhook handling, GitHub Actions, PRs, issues, releases, and deployments",
   "source": "github.com/GoCodeAlone/workflow-plugin-github",

--- a/plugins/salesforce/manifest.json
+++ b/plugins/salesforce/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-salesforce",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Salesforce CRM — records, SOQL queries, bulk operations, approvals, flows, reports, dashboards, metadata, and more",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/sso/manifest.json
+++ b/plugins/sso/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-sso",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Enterprise SSO via OpenID Connect with multi-provider support",
   "author": "GoCodeAlone",
   "license": "MIT",

--- a/plugins/twilio/manifest.json
+++ b/plugins/twilio/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-twilio",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Comprehensive Twilio integration — SMS, Voice, Verify, Video, Conversations, TaskRouter, and 40+ products",
   "author": "GoCodeAlone",
   "license": "MIT",


### PR DESCRIPTION
Sync `version` fields in plugin manifests to match the latest git release tags for each plugin. These manifests had drifted behind actual releases, causing consumers and tooling to see stale version data.

## Changes

| Plugin | Registry was | Updated to |
|--------|-------------|------------|
| digitalocean | 1.0.7 | 1.0.12 |
| admin | 1.0.1 | 1.1.1 |
| agent | 0.5.2 | 0.9.2 |
| approval | 0.1.1 | 0.1.2 |
| ci-generator | 0.1.2 | 0.1.3 |
| github | 1.0.2 | 1.0.3 |
| salesforce | 0.2.1 | 0.2.2 |
| sso | 0.1.1 | 0.1.3 |
| twilio | 0.1.3 | 0.2.0 |
| authz | 0.5.2 | 0.5.3 |

Corresponding `plugin.json` sync PRs were merged in each plugin repo in the same batch.