### PR TITLE
feat: bump aws/gcp/azure plugin manifests to v2.0.0 (workflow#699)

### DIFF
--- a/plugins/aws/manifest.json
+++ b/plugins/aws/manifest.json
@@ -1,16 +1,30 @@
 {
   "name": "workflow-plugin-aws",
-  "version": "0.1.2",
+  "version": "2.0.0",
   "description": "AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, and ACM resources",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",
   "tier": "community",
   "private": false,
-  "minEngineVersion": "0.3.51",
+  "minEngineVersion": "0.57.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-aws",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-aws",
-  "keywords": ["aws", "iac", "infrastructure", "cloud", "ecs", "eks", "rds", "elasticache", "vpc", "alb", "route53", "ecr", "s3"],
+  "keywords": [
+    "aws",
+    "iac",
+    "infrastructure",
+    "cloud",
+    "ecs",
+    "eks",
+    "rds",
+    "elasticache",
+    "vpc",
+    "alb",
+    "route53",
+    "ecr",
+    "s3"
+  ],
   "capabilities": {
     "moduleTypes": [],
     "stepTypes": [],
@@ -24,22 +38,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.1.2/workflow-plugin-aws-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/azure/manifest.json
+++ b/plugins/azure/manifest.json
@@ -1,16 +1,28 @@
 {
   "name": "workflow-plugin-azure",
-  "version": "0.1.2",
+  "version": "2.0.0",
   "description": "Microsoft Azure infrastructure provider: ACI, AKS, SQL, Redis, VNet, LB, DNS, ACR, APIM, NSG, MSI, Blob Storage, App Service Certificates",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",
   "tier": "community",
   "private": false,
-  "minEngineVersion": "0.3.51",
+  "minEngineVersion": "0.57.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-azure",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-azure",
-  "keywords": ["azure", "iac", "infrastructure", "cloud", "aci", "aks", "sql", "redis", "vnet", "acr", "apim"],
+  "keywords": [
+    "azure",
+    "iac",
+    "infrastructure",
+    "cloud",
+    "aci",
+    "aks",
+    "sql",
+    "redis",
+    "vnet",
+    "acr",
+    "apim"
+  ],
   "capabilities": {
     "moduleTypes": [],
     "stepTypes": [],
@@ -24,22 +36,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.0.0/workflow-plugin-azure-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.0.0/workflow-plugin-azure-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.0.0/workflow-plugin-azure-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v0.1.2/workflow-plugin-azure-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.0.0/workflow-plugin-azure-darwin-arm64.tar.gz"
     }
   ]
 }

--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -1,16 +1,26 @@
 {
   "name": "workflow-plugin-gcp",
-  "version": "0.1.3",
+  "version": "2.0.0",
   "description": "GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",
   "tier": "community",
   "private": false,
-  "minEngineVersion": "0.3.51",
+  "minEngineVersion": "0.57.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
-  "keywords": ["gcp", "google-cloud", "iac", "infrastructure", "cloud-run", "gke", "cloud-sql", "memorystore", "gcs"],
+  "keywords": [
+    "gcp",
+    "google-cloud",
+    "iac",
+    "infrastructure",
+    "cloud-run",
+    "gke",
+    "cloud-sql",
+    "memorystore",
+    "gcs"
+  ],
   "capabilities": {
     "moduleTypes": [],
     "stepTypes": [],
@@ -24,22 +34,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.0.0/workflow-plugin-gcp-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.0.0/workflow-plugin-gcp-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.0.0/workflow-plugin-gcp-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v0.1.3/workflow-plugin-gcp-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.0.0/workflow-plugin-gcp-darwin-arm64.tar.gz"
     }
   ]
 }


### PR DESCRIPTION
Per workflow#699 cascade. workflow v0.57.0 ships with Apply removed; plugin v2.0.0 majors drop Apply.

## Changes
- aws v0.1.2 → v2.0.0
- gcp v0.1.3 → v2.0.0
- azure v0.1.2 → v2.0.0
- All: minEngineVersion 0.3.51 → 0.57.0

## Rollback floors
- aws: v1.2.1, gcp: v1.2.0, azure: v1.2.1

digitalocean PR follows after workflow-plugin-digitalocean#125 lands.