### PR TITLE
fix(registry): declare digitalocean iac v2 metadata

### DIFF
--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -94,6 +94,9 @@
       ]
     }
   },
+  "iacProvider": {
+    "computePlanVersion": "v2"
+  },
   "assets": {
     "ui": false,
     "config": true

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -166,6 +166,27 @@
       },
       "additionalProperties": false
     },
+    "iacProvider": {
+      "type": "object",
+      "description": "IaC provider runtime metadata used by wfctl after plugin install",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Canonical provider name when declared at top level"
+        },
+        "resourceTypes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Resource types this provider's drivers can manage"
+        },
+        "computePlanVersion": {
+          "type": "string",
+          "enum": ["v1", "v2"],
+          "description": "wfctl IaC compute/apply plan dispatch version; v2 enables the modern typed provider path"
+        }
+      },
+      "additionalProperties": false
+    },
     "checksums": {
       "type": "object",
       "description": "SHA-256 checksums keyed by version string for integrity verification",


### PR DESCRIPTION
## Summary
- Allow top-level iacProvider runtime metadata in registry manifests
- Declare workflow-plugin-digitalocean computePlanVersion as v2

## Verification
- bash scripts/validate-manifests.sh
- jq empty plugins/digitalocean/manifest.json schema/registry-schema.json
- git diff --check

## Context
BMW deploy logs showed wfctl warning that the installed DigitalOcean plugin manifest had empty iacProvider.computePlanVersion. Workflow PR #710 preserves this field during install; this PR adds the registry-side declaration.