### PR TITLE
feat(schema): add optional status enum to registry-schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ wfctl init my-project --template api-service
 
 All plugin manifests must conform to the [registry schema](./schema/registry-schema.json). The schema is a JSON Schema (draft 2020-12) defining required fields, enums for `type`, `tier`, and `status`, and the structure of `capabilities`.
 
+The optional `status` field tracks active-usage verification: `"verified"` means the plugin is pinned in a merged main-branch `wfctl.yaml` of an active GoCodeAlone project (production miles); `"experimental"` means it compiles and unit-tests pass but has no validated production deployment; `"deprecated"` means it is scheduled for removal. Manifests without `status` continue to validate — the field is optional and additive.
+
 Validate a manifest locally:
 
 ```bash
@@ -197,6 +199,7 @@ PRs that fail validation cannot be merged.
 - `repository` should point to the public GitHub repository where the plugin lives
 - `capabilities.moduleTypes`, `stepTypes`, `triggerTypes`, `workflowHandlers` must accurately reflect what the plugin registers
 - `private: true` must be set for plugins that are not publicly installable
+- `status` is optional; if set, must be one of `"verified"`, `"experimental"`, or `"deprecated"` (see Schema section)
 
 ### Review Process
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ wfctl init my-project --template api-service
 
 ## Schema
 
-All plugin manifests must conform to the [registry schema](./schema/registry-schema.json). The schema is a JSON Schema (draft 2020-12) defining required fields, enums for `type` and `tier`, and the structure of `capabilities`.
+All plugin manifests must conform to the [registry schema](./schema/registry-schema.json). The schema is a JSON Schema (draft 2020-12) defining required fields, enums for `type`, `tier`, and `status`, and the structure of `capabilities`.
 
 Validate a manifest locally:
 

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -41,6 +41,11 @@
       "enum": ["core", "community", "premium"],
       "description": "Plugin tier: core (maintained by GoCodeAlone), community (third-party), premium (paid)"
     },
+    "status": {
+      "type": "string",
+      "enum": ["verified", "experimental", "deprecated"],
+      "description": "Active-usage verification status. 'verified' = pinned in a merged main-branch wfctl.yaml of an active GoCodeAlone project; 'experimental' = compiles + unit-tests pass but no verified production usage; 'deprecated' = scheduled removal."
+    },
     "license": {
       "type": "string",
       "description": "SPDX license identifier (e.g. MIT, Apache-2.0)"


### PR DESCRIPTION
## Summary

- Adds an optional `status` property to `schema/registry-schema.json` with enum values `verified | experimental | deprecated`
- Field is **not** in the `required` array — all 59 existing manifests continue to pass `ajv validate --spec=draft2020`
- Bogus values (e.g. `status: "bogus"`) correctly fail the enum check
- Updates README Schema section to list `status` alongside `type` and `tier` enums

## Status enum semantics

| Value | Meaning |
|---|---|
| `verified` | Pinned in a merged main-branch `wfctl.yaml` of an active GoCodeAlone project |
| `experimental` | Compiles + unit-tests pass but no verified production usage |
| `deprecated` | Scheduled removal |

## Related

- Manifest population (setting `status` values on plugin entries) follows in PR-R2 once this PR + the workflow RegistryManifest struct PR both merge
- Companion workflow Go struct PR adds `Status` field to `PluginSummary` (Task 1)

## Test plan

- [x] `ajv validate --spec=draft2020 -s schema/registry-schema.json -d plugins/*/manifest.json` → all 59 pass
- [x] Probe with `status: "experimental"` → valid
- [x] Probe with `status: "bogus"` → fails enum check

## Rollback

Revert this PR. Existing manifests are unaffected — `status` was never required, so manifests without the field continue to validate against the original schema. If Task 16 (manifest population CI) has already merged when a rollback is needed, revert Task 16 first to keep registry CI green, then revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)