### PR TITLE
feat(registry): add stub manifests for 10 public plugins

### DIFF
--- a/plugins/broker/manifest.json
+++ b/plugins/broker/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-broker",
+  "version": "0.2.2",
+  "author": "GoCodeAlone",
+  "description": "External plugin for the workflow engine.",
+  "source": "github.com/GoCodeAlone/workflow-plugin-broker",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-broker",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-broker",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/infra/manifest.json
+++ b/plugins/infra/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-infra",
+  "version": "0.1.0",
+  "author": "GoCodeAlone",
+  "description": "External plugin for the workflow engine.",
+  "source": "github.com/GoCodeAlone/workflow-plugin-infra",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-infra",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-infra",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/marketplace/manifest.json
+++ b/plugins/marketplace/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-marketplace",
+  "version": "0.1.0",
+  "author": "GoCodeAlone",
+  "description": "External plugin for the workflow engine.",
+  "source": "github.com/GoCodeAlone/workflow-plugin-marketplace",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-marketplace",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-marketplace",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/mcp/manifest.json
+++ b/plugins/mcp/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-mcp",
+  "version": "0.1.0",
+  "author": "GoCodeAlone",
+  "description": "MCP (Model Context Protocol) plugin for GoCodeAlone/workflow",
+  "source": "github.com/GoCodeAlone/workflow-plugin-mcp",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-mcp",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-mcp",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/messaging-core/manifest.json
+++ b/plugins/messaging-core/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-messaging-core",
+  "version": "0.1.0",
+  "author": "GoCodeAlone",
+  "description": "Shared messaging interfaces for workflow platform plugins",
+  "source": "github.com/GoCodeAlone/workflow-plugin-messaging-core",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-messaging-core",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-messaging-core",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/rooms/manifest.json
+++ b/plugins/rooms/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-rooms",
+  "version": "0.1.5",
+  "author": "GoCodeAlone",
+  "description": "Room management plugin for workflow engine — join, leave, broadcast, members",
+  "source": "github.com/GoCodeAlone/workflow-plugin-rooms",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-rooms",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-rooms",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/security-scanner/manifest.json
+++ b/plugins/security-scanner/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-security-scanner",
+  "version": "1.0.2",
+  "author": "GoCodeAlone",
+  "description": "Security scanner plugin for workflow engine — vulnerability scanning, secret detection, and compliance checks",
+  "source": "github.com/GoCodeAlone/workflow-plugin-security-scanner",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-security-scanner",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-security-scanner",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/steam/manifest.json
+++ b/plugins/steam/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-steam",
+  "version": "0.3.2",
+  "author": "GoCodeAlone",
+  "description": "External plugin for the workflow engine.",
+  "source": "github.com/GoCodeAlone/workflow-plugin-steam",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-steam",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-steam",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/template/manifest.json
+++ b/plugins/template/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-template",
+  "version": "0.1.0",
+  "author": "GoCodeAlone",
+  "description": "Template repository for creating workflow engine external plugins",
+  "source": "github.com/GoCodeAlone/workflow-plugin-template",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-template",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-template",
+  "private": false,
+  "status": "experimental"
+}

--- a/plugins/ws-auth/manifest.json
+++ b/plugins/ws-auth/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflow-plugin-ws-auth",
+  "version": "0.1.4",
+  "author": "GoCodeAlone",
+  "description": "WebSocket HMAC authentication plugin for workflow engine",
+  "source": "github.com/GoCodeAlone/workflow-plugin-ws-auth",
+  "type": "external",
+  "tier": "community",
+  "license": "MIT",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-ws-auth",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-ws-auth",
+  "private": false,
+  "status": "experimental"
+}


### PR DESCRIPTION
## Summary

- Adds minimal `manifest.json` entries for 10 GoCodeAlone-owned public plugin repos that previously lacked registry presence.
- Each manifest has required identity fields + `status: experimental`.
- Capabilities (moduleTypes / stepTypes / iacProvider) intentionally absent — to be added in follow-up PRs after extracting from source.
- This stub layer lets `wfctl marketplace` discover the plugins; capability accuracy is layered on later.

Plugins added:
- broker, infra, marketplace, mcp, messaging-core, rooms, security-scanner, steam, template, ws-auth

Closes: #55 #57 #59 #60 #61 #62 #63 #64 #65 #66 #67

## Test plan

- [x] `ajv validate --spec=draft2020 -s schema/registry-schema.json -d 'plugins/*/manifest.json'` — all valid.
- [ ] CI registry validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)