### PR TITLE
feat(registry): enrich 10 stub manifests with capability data

### DIFF
--- a/plugins/broker/manifest.json
+++ b/plugins/broker/manifest.json
@@ -10,5 +10,16 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-broker",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-broker",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [
+      "messaging.broker.workflow"
+    ],
+    "stepTypes": [
+      "step.broker_publish",
+      "step.broker_subscribe"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/infra/manifest.json
+++ b/plugins/infra/manifest.json
@@ -10,5 +10,14 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-infra",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-infra",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [
+      "infra.cache",
+      "infra.registry"
+    ],
+    "stepTypes": [],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/marketplace/manifest.json
+++ b/plugins/marketplace/manifest.json
@@ -10,5 +10,18 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-marketplace",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-marketplace",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [],
+    "stepTypes": [
+      "step.marketplace_search",
+      "step.marketplace_detail",
+      "step.marketplace_install",
+      "step.marketplace_installed",
+      "step.marketplace_uninstall",
+      "step.marketplace_update"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/mcp/manifest.json
+++ b/plugins/mcp/manifest.json
@@ -10,5 +10,13 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-mcp",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-mcp",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [
+      "mcp.server"
+    ],
+    "stepTypes": [],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/messaging-core/manifest.json
+++ b/plugins/messaging-core/manifest.json
@@ -10,5 +10,16 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-messaging-core",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-messaging-core",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [],
+    "stepTypes": [
+      "step.messaging_send",
+      "step.messaging_reply",
+      "step.messaging_receive",
+      "step.messaging_react"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/rooms/manifest.json
+++ b/plugins/rooms/manifest.json
@@ -10,5 +10,16 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-rooms",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-rooms",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [],
+    "stepTypes": [
+      "step.room_join",
+      "step.room_leave",
+      "step.room_broadcast",
+      "step.room_members"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/security-scanner/manifest.json
+++ b/plugins/security-scanner/manifest.json
@@ -10,5 +10,15 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-security-scanner",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-security-scanner",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [],
+    "stepTypes": [
+      "step.sast_scan",
+      "step.container_scan",
+      "step.deps_scan"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/steam/manifest.json
+++ b/plugins/steam/manifest.json
@@ -10,5 +10,16 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-steam",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-steam",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [],
+    "stepTypes": [
+      "step.steam_auth",
+      "step.steam_achievement_set",
+      "step.steam_achievement_sync",
+      "step.steam_stat_set"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/template/manifest.json
+++ b/plugins/template/manifest.json
@@ -10,5 +10,15 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-template",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-template",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [
+      "example.module_type"
+    ],
+    "stepTypes": [
+      "step.example_action"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }

--- a/plugins/ws-auth/manifest.json
+++ b/plugins/ws-auth/manifest.json
@@ -10,5 +10,13 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-ws-auth",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-ws-auth",
   "private": false,
-  "status": "experimental"
+  "status": "experimental",
+  "capabilities": {
+    "moduleTypes": [],
+    "stepTypes": [
+      "step.ws_auth_identity"
+    ],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  }
 }


### PR DESCRIPTION
Follow-up to #68. Adds moduleTypes/stepTypes per plugin extracted from each repo's source code. Closes the registry-side capability-enrichment item from workflow#730. All manifests still ajv-valid.