### PR TITLE
feat: namecheap + hover DNS plugin manifests + required_secrets schema

### DIFF
--- a/plugins/hover/manifest.json
+++ b/plugins/hover/manifest.json
@@ -1,0 +1,47 @@
+{
+  "name": "workflow-plugin-hover",
+  "version": "0.1.0",
+  "minEngineVersion": "0.60.6",
+  "description": "Hover DNS provider for workflow IaC (infra.dns). No official API; mimics the browser-side username+password+TOTP login flow used by pjslauta/hover-dyn-dns.",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-hover",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-hover",
+  "keywords": [
+    "dns",
+    "hover",
+    "iac",
+    "infra.dns",
+    "totp"
+  ],
+  "capabilities": {
+    "moduleTypes": [
+      "iac.provider.hover"
+    ],
+    "stepTypes": [],
+    "triggerTypes": [],
+    "iacProvider": {
+      "name": "hover",
+      "resourceTypes": [
+        "infra.dns"
+      ]
+    }
+  },
+  "required_secrets": [
+    { "name": "HOVER_USERNAME", "sensitive": false, "description": "Hover account username", "prompt": "Hover username" },
+    { "name": "HOVER_PASSWORD", "sensitive": true, "description": "Hover account password", "prompt": "Hover password" },
+    { "name": "HOVER_TOTP_SECRET", "sensitive": true, "description": "Base32-encoded TOTP seed from Hover 2FA setup. Plugin generates 6-digit codes per RFC 6238 on each login.", "prompt": "Hover TOTP seed (base32)" }
+  ],
+  "iacProvider": {
+    "computePlanVersion": "v2"
+  },
+  "assets": {
+    "ui": false,
+    "config": true
+  },
+  "downloads": [],
+  "status": "experimental"
+}

--- a/plugins/namecheap/manifest.json
+++ b/plugins/namecheap/manifest.json
@@ -1,0 +1,46 @@
+{
+  "name": "workflow-plugin-namecheap",
+  "version": "0.1.0",
+  "minEngineVersion": "0.60.6",
+  "description": "Namecheap DNS provider for workflow IaC (infra.dns) backed by the official go-namecheap-sdk.",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-namecheap",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-namecheap",
+  "keywords": [
+    "dns",
+    "namecheap",
+    "iac",
+    "infra.dns"
+  ],
+  "capabilities": {
+    "moduleTypes": [
+      "iac.provider.namecheap"
+    ],
+    "stepTypes": [],
+    "triggerTypes": [],
+    "iacProvider": {
+      "name": "namecheap",
+      "resourceTypes": [
+        "infra.dns"
+      ]
+    }
+  },
+  "required_secrets": [
+    { "name": "NAMECHEAP_API_USER", "sensitive": false, "description": "Namecheap account username (= ApiUser per API)", "prompt": "Namecheap username" },
+    { "name": "NAMECHEAP_API_KEY", "sensitive": true, "description": "Namecheap API key (rotate via Profile → Tools → Namecheap API Access)", "prompt": "Namecheap API key" },
+    { "name": "NAMECHEAP_CLIENT_IP", "sensitive": false, "description": "Public IP of the wfctl runner — Namecheap requires single-IP allowlisting (CIDR is unsupported)", "prompt": "Public IP to whitelist" }
+  ],
+  "iacProvider": {
+    "computePlanVersion": "v2"
+  },
+  "assets": {
+    "ui": false,
+    "config": true
+  },
+  "downloads": [],
+  "status": "experimental"
+}

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -286,6 +286,33 @@
         },
         "additionalProperties": false
       }
+    },
+    "required_secrets": {
+      "type": "array",
+      "description": "Secrets the plugin requires to be set in the host environment. Consumed by `wfctl secrets setup --plugin <name>` to drive interactive prompts.",
+      "items": {
+        "type": "object",
+        "required": ["name", "sensitive"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Env var name (e.g. NAMECHEAP_API_KEY)"
+          },
+          "sensitive": {
+            "type": "boolean",
+            "description": "When true, wfctl prompts via term.ReadPassword (masked) instead of echo"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description shown above the prompt"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Optional short prompt label (defaults to name)"
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Per workflow#735 SPEC T17. Two new plugin manifests + schema extension for plugin-declared required_secrets[].