### PR TITLE
feat(registry): populate downloads for namecheap + hover v0.1.0

### DIFF
--- a/plugins/cms/manifest.json
+++ b/plugins/cms/manifest.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-cms",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-cms",
   "capabilities": {
-    "configProvider": false,
     "moduleTypes": [
       "cms.tenant_resolver",
       "cms.static_serve_before_dynamic",
@@ -32,6 +31,5 @@
     ],
     "triggerTypes": []
   },
-  "contracts": [],
   "status": "experimental"
 }

--- a/plugins/hover/manifest.json
+++ b/plugins/hover/manifest.json
@@ -31,9 +31,24 @@
     }
   },
   "required_secrets": [
-    { "name": "HOVER_USERNAME", "sensitive": false, "description": "Hover account username", "prompt": "Hover username" },
-    { "name": "HOVER_PASSWORD", "sensitive": true, "description": "Hover account password", "prompt": "Hover password" },
-    { "name": "HOVER_TOTP_SECRET", "sensitive": true, "description": "Base32-encoded TOTP seed from Hover 2FA setup. Plugin generates 6-digit codes per RFC 6238 on each login.", "prompt": "Hover TOTP seed (base32)" }
+    {
+      "name": "HOVER_USERNAME",
+      "sensitive": false,
+      "description": "Hover account username",
+      "prompt": "Hover username"
+    },
+    {
+      "name": "HOVER_PASSWORD",
+      "sensitive": true,
+      "description": "Hover account password",
+      "prompt": "Hover password"
+    },
+    {
+      "name": "HOVER_TOTP_SECRET",
+      "sensitive": true,
+      "description": "Base32-encoded TOTP seed from Hover 2FA setup. Plugin generates 6-digit codes per RFC 6238 on each login.",
+      "prompt": "Hover TOTP seed (base32)"
+    }
   ],
   "iacProvider": {
     "computePlanVersion": "v2"
@@ -42,6 +57,31 @@
     "ui": false,
     "config": true
   },
-  "downloads": [],
+  "downloads": [
+    {
+      "arch": "amd64",
+      "os": "darwin",
+      "sha256": "268376d385f8db7b129ffaa567e994af0f05d73c6f9cb5ba89aba98e1a5beb4d",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.1.0/workflow-plugin-hover-darwin-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "sha256": "26d17c53035f75da6e2fcb9b23eef30ed518d1c70ab25837e89b59b25a7c4c32",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.1.0/workflow-plugin-hover-darwin-arm64.tar.gz"
+    },
+    {
+      "arch": "amd64",
+      "os": "linux",
+      "sha256": "d931e820a64a7bfbaf46fd4999fb801d26c95e0abc5af95e754cffc3687177d7",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.1.0/workflow-plugin-hover-linux-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "linux",
+      "sha256": "ddc6f32cefbf76fe4e7595ca460443edb4c3022220dc9b18600597f3e9f296fe",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.1.0/workflow-plugin-hover-linux-arm64.tar.gz"
+    }
+  ],
   "status": "experimental"
 }

--- a/plugins/namecheap/manifest.json
+++ b/plugins/namecheap/manifest.json
@@ -30,9 +30,24 @@
     }
   },
   "required_secrets": [
-    { "name": "NAMECHEAP_API_USER", "sensitive": false, "description": "Namecheap account username (= ApiUser per API)", "prompt": "Namecheap username" },
-    { "name": "NAMECHEAP_API_KEY", "sensitive": true, "description": "Namecheap API key (rotate via Profile → Tools → Namecheap API Access)", "prompt": "Namecheap API key" },
-    { "name": "NAMECHEAP_CLIENT_IP", "sensitive": false, "description": "Public IP of the wfctl runner — Namecheap requires single-IP allowlisting (CIDR is unsupported)", "prompt": "Public IP to whitelist" }
+    {
+      "name": "NAMECHEAP_API_USER",
+      "sensitive": false,
+      "description": "Namecheap account username (= ApiUser per API)",
+      "prompt": "Namecheap username"
+    },
+    {
+      "name": "NAMECHEAP_API_KEY",
+      "sensitive": true,
+      "description": "Namecheap API key (rotate via Profile → Tools → Namecheap API Access)",
+      "prompt": "Namecheap API key"
+    },
+    {
+      "name": "NAMECHEAP_CLIENT_IP",
+      "sensitive": false,
+      "description": "Public IP of the wfctl runner — Namecheap requires single-IP allowlisting (CIDR is unsupported)",
+      "prompt": "Public IP to whitelist"
+    }
   ],
   "iacProvider": {
     "computePlanVersion": "v2"
@@ -41,6 +56,31 @@
     "ui": false,
     "config": true
   },
-  "downloads": [],
+  "downloads": [
+    {
+      "arch": "amd64",
+      "os": "darwin",
+      "sha256": "3be50b8248775e76166357de90d239dac952a806cb71253927db25d5edbad05b",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.0/workflow-plugin-namecheap-darwin-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "sha256": "506e5bfee46667a57c56764898628b2337bdf04564c7e147c9541bf2c1894974",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.0/workflow-plugin-namecheap-darwin-arm64.tar.gz"
+    },
+    {
+      "arch": "amd64",
+      "os": "linux",
+      "sha256": "0cd4c835a07d8d476e31fcb169bf72ea0bbb00a13bc02665d6cf5c8c1bcda2f8",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.0/workflow-plugin-namecheap-linux-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "linux",
+      "sha256": "3e2f90f40d4c05e65a7ddba390ba275397757c8a334512778b2b8599030b7023",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.0/workflow-plugin-namecheap-linux-arm64.tar.gz"
+    }
+  ],
   "status": "experimental"
 }


### PR DESCRIPTION
## Summary

Both DNS plugins shipped v0.1.0 today; release workflows in each repo built and published linux/darwin × amd64/arm64 tar.gz archives plus checksums. Populating the previously-empty `downloads: []` arrays in their registry manifests so:

- `wfctl plugin search dns` surfaces both
- `wfctl plugin install workflow-plugin-namecheap` / `workflow-plugin-hover` resolves URLs + sha256 verifies the artifact

## Verification

```
$ gh release download v0.1.0 --repo GoCodeAlone/workflow-plugin-namecheap --pattern checksums.txt --output -
3be50b8248775e76166357de90d239dac952a806cb71253927db25d5edbad05b  workflow-plugin-namecheap-darwin-amd64.tar.gz
506e5bfee46667a57c56764898628b2337bdf04564c7e147c9541bf2c1894974  workflow-plugin-namecheap-darwin-arm64.tar.gz
0cd4c835a07d8d476e31fcb169bf72ea0bbb00a13bc02665d6cf5c8c1bcda2f8  workflow-plugin-namecheap-linux-amd64.tar.gz
3e2f90f40d4c05e65a7ddba390ba275397757c8a334512778b2b8599030b7023  workflow-plugin-namecheap-linux-arm64.tar.gz

$ gh release download v0.1.0 --repo GoCodeAlone/workflow-plugin-hover --pattern checksums.txt --output -
268376d385f8db7b129ffaa567e994af0f05d73c6f9cb5ba89aba98e1a5beb4d  workflow-plugin-hover-darwin-amd64.tar.gz
26d17c53035f75da6e2fcb9b23eef30ed518d1c70ab25837e89b59b25a7c4c32  workflow-plugin-hover-darwin-arm64.tar.gz
d931e820a64a7bfbaf46fd4999fb801d26c95e0abc5af95e754cffc3687177d7  workflow-plugin-hover-linux-amd64.tar.gz
ddc6f32cefbf76fe4e7595ca460443edb4c3022220dc9b18600597f3e9f296fe  workflow-plugin-hover-linux-arm64.tar.gz
```

These match the values written into the two manifests in this PR.

## Test plan

- [x] `jq` validates both manifests parse + have non-empty `downloads`.
- [ ] Manifest schema CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)