### PR TITLE
Add workflow-compute plugin manifest

### DIFF
--- a/plugins/workflow-plugin-compute/manifest.json
+++ b/plugins/workflow-plugin-compute/manifest.json
@@ -1,0 +1,53 @@
+{
+  "name": "workflow-plugin-compute",
+  "version": "0.1.1",
+  "description": "Workflow adapter for workflow-compute dispatch, wait, map, provider, pool, catalog, and product-capture workloads",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "minEngineVersion": "0.57.4",
+  "keywords": [
+    "workflow-compute",
+    "distributed-compute",
+    "product-capture",
+    "proof"
+  ],
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-compute",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-compute",
+  "capabilities": {
+    "moduleTypes": [
+      "compute.provider",
+      "compute.pool",
+      "compute.provider_catalog"
+    ],
+    "stepTypes": [
+      "step.compute_dispatch",
+      "step.compute_wait",
+      "step.compute_map",
+      "step.compute_product_capture"
+    ],
+    "triggerTypes": [],
+    "cliCommands": [
+      {
+        "name": "compute",
+        "description": "Operate a workflow-compute control plane",
+        "flags_passthrough": true
+      }
+    ]
+  },
+  "downloads": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.1/workflow-plugin-compute-linux-amd64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.1/workflow-plugin-compute-darwin-arm64.tar.gz"
+    }
+  ],
+  "status": "verified"
+}


### PR DESCRIPTION
## Summary
- register `workflow-plugin-compute` v0.1.1 in the central plugin registry
- advertise compute module/step capabilities, including `step.compute_product_capture`
- point install metadata at the released linux/amd64 and darwin/arm64 archives

## Validation
- `scripts/validate-manifests.sh`
- `scripts/build-index.sh`