### PR TITLE
Update compute plugin to v0.1.2

### DIFF
--- a/plugins/workflow-plugin-compute/manifest.json
+++ b/plugins/workflow-plugin-compute/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-compute",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Workflow adapter for workflow-compute dispatch, wait, map, provider, pool, catalog, and product-capture workloads",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -41,12 +41,12 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.1/workflow-plugin-compute-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.2/workflow-plugin-compute-linux-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.1/workflow-plugin-compute-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.2/workflow-plugin-compute-darwin-arm64.tar.gz"
     }
   ],
   "status": "verified"


### PR DESCRIPTION
## Summary
- update `workflow-plugin-compute` registry manifest to v0.1.2
- point linux/amd64 and darwin/arm64 downloads at the v0.1.2 release assets

## Validation
- `scripts/validate-manifests.sh`
- `scripts/build-index.sh`

## Context
v0.1.2 fixes strict runtime decode of Workflow's internal `_config_dir` field, which BMW PR #346 hit in image-launch.