### PR TITLE
fix(schema): admit configProvider/serviceMethods/iacStateBackends/iacProvider.configSchema

### DIFF
--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -23,7 +23,7 @@
       {
         "name": "payments",
         "description": "Payment provider operations (webhook ensure, …)",
-        "flagsPassthrough": true
+        "flags_passthrough": true
       }
     ]
   },

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -54,6 +54,10 @@
       "type": "object",
       "description": "Capability declarations for the plugin",
       "properties": {
+        "configProvider": {
+          "type": "boolean",
+          "description": "Whether the plugin implements the engine's ConfigProvider interface (provides config fragments via the plugin SDK). Mirrors RegistryCapabilities.ConfigProvider in workflow/cmd/wfctl/plugin_registry.go."
+        },
         "moduleTypes": {
           "type": "array",
           "items": { "type": "string" },
@@ -79,6 +83,16 @@
           "items": { "type": "string" },
           "description": "Post-init wiring hook names this plugin provides"
         },
+        "serviceMethods": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "gRPC service methods this plugin exposes via the engine (e.g. audit.collector/query). Mirrors RegistryCapabilities.ServiceMethods in workflow/cmd/wfctl/plugin_registry.go."
+        },
+        "iacStateBackends": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "IaC state-storage backends this plugin's drivers can manage (e.g. spaces, gcs, s3). Provider-specific list — not all IaC providers expose a state backend, so this is separate from iacProvider.resourceTypes."
+        },
         "iacProvider": {
           "type": "object",
           "description": "IaC provider declaration — name and supported resource types",
@@ -96,6 +110,11 @@
               "type": "array",
               "items": { "type": "string" },
               "description": "Canonical config keys this provider's drivers can map (e.g. name, region, image, env_vars)"
+            },
+            "configSchema": {
+              "type": "object",
+              "description": "Provider-specific schema for resource configuration fragments, keyed by resource type (e.g. infra.container_service → { field: { type, enum, default, description } }). Free-form because each provider's per-resource schema is independent.",
+              "additionalProperties": true
             }
           },
           "required": ["name"],

--- a/scripts/build-index.sh
+++ b/scripts/build-index.sh
@@ -83,6 +83,10 @@ while IFS= read -r manifest; do
   # G3-include: capabilities.workflowHandlers
   # G3-include: capabilities.wiringHooks
   # G3-include: capabilities.migrationDrivers
+  # G3-include: capabilities.configProvider
+  # G3-include: capabilities.iacStateBackends
+  # G3-exclude: capabilities.serviceMethods — engine-internal gRPC method names, not user-facing search
+  # G3-exclude: capabilities.iacProvider.configSchema — large free-form per-resource schema (DO's is ~10KB); per-plugin manifest carries it
   # G3-include: capabilities.iacProvider
   # G3-include: capabilities.iacProvider.name
   # G3-include: capabilities.iacProvider.resourceTypes
@@ -135,12 +139,14 @@ while IFS= read -r manifest; do
       }]
     ),
     capabilities: {
+      configProvider:   (.capabilities.configProvider   // false),
       moduleTypes:      (.capabilities.moduleTypes      // []),
       stepTypes:        (.capabilities.stepTypes        // []),
       triggerTypes:     (.capabilities.triggerTypes     // []),
       workflowHandlers: (.capabilities.workflowHandlers // []),
       wiringHooks:      (.capabilities.wiringHooks      // []),
       migrationDrivers: (.capabilities.migrationDrivers // []),
+      iacStateBackends: (.capabilities.iacStateBackends // []),
       iacProvider: (
         if .capabilities.iacProvider == null then null
         else {

--- a/tests/fixtures/plugins/foo-iac/manifest.json
+++ b/tests/fixtures/plugins/foo-iac/manifest.json
@@ -14,10 +14,14 @@
   "keywords": ["dns", "iac"],
   "capabilities": {
     "moduleTypes": ["iac.provider.foo"],
+    "configProvider": true,
+    "iacStateBackends": ["spaces", "gcs"],
+    "serviceMethods": ["foo.collector/query", "foo.collector/stats"],
     "iacProvider": {
       "name": "foo",
       "resourceTypes": ["infra.dns", "infra.dns_delegation"],
-      "supportedCanonicalKeys": ["zone", "record"]
+      "supportedCanonicalKeys": ["zone", "record"],
+      "configSchema": {"infra.dns": {"ttl": {"type": "integer"}}}
     },
     "cliCommands": [
       {

--- a/tests/test-build-index.sh
+++ b/tests/test-build-index.sh
@@ -96,6 +96,19 @@ assert_jq "cliCommands item has exactly 4 known keys" \
   '.[] | select(.name=="foo-iac") | .capabilities.cliCommands[0] | keys_unsorted | sort' \
   '["description","flags_passthrough","name","subcommands"]'
 
+# === schema-extension-pr fields ===
+# configProvider + iacStateBackends are included; serviceMethods + iacProvider.configSchema are excluded.
+assert_jq "foo-iac capabilities.configProvider preserved" \
+  '.[] | select(.name=="foo-iac") | .capabilities.configProvider' 'true'
+assert_jq "foo-iac capabilities.iacStateBackends preserved" \
+  '.[] | select(.name=="foo-iac") | .capabilities.iacStateBackends' '["spaces","gcs"]'
+if jq -e '.[] | select(.name=="foo-iac") | .capabilities | has("serviceMethods")' "${INDEX}" >/dev/null; then
+  fail "G3 allowlist regression: capabilities.serviceMethods leaked into index (engine-internal)"
+fi
+if jq -e '.[] | select(.name=="foo-iac") | .capabilities.iacProvider | has("configSchema")' "${INDEX}" >/dev/null; then
+  fail "G3 allowlist regression: capabilities.iacProvider.configSchema leaked into index (large free-form payload)"
+fi
+
 # === Per-key allowlist on assets (round-2 Copilot — extras dropped) ===
 assert_jq "assets has exactly 2 known keys (ui, config)" \
   '.[] | select(.name=="foo-iac") | .assets | keys_unsorted | sort' \


### PR DESCRIPTION
## Summary

Pre-existing CI breakage on `main` after #83 synced plugin manifests with four properties the schema rejected. All four properties have engine-side counterparts (`RegistryCapabilities` struct in `workflow/cmd/wfctl/plugin_registry.go`). This PR adds them to the schema with allowlist decisions for the `v1/index.json` projection.

## Changes

- `schema/registry-schema.json`:
  - `capabilities.configProvider: boolean` (engine `ConfigProvider bool`)
  - `capabilities.serviceMethods: []string` (engine `ServiceMethods []string`)
  - `capabilities.iacStateBackends: []string` (provider-specific state backends)
  - `capabilities.iacProvider.configSchema: object` (provider per-resource schema, free-form)
- `scripts/build-index.sh`: G3 marker decisions
  - `configProvider` + `iacStateBackends` → INCLUDE in v1/index.json (search filters)
  - `serviceMethods` → EXCLUDE (engine-internal, not user-facing)
  - `iacProvider.configSchema` → EXCLUDE (large free-form payload; per-plugin manifest carries full fidelity)
- `tests/test-build-index.sh`: 4 new assertions covering the include + exclude decisions
- `tests/fixtures/plugins/foo-iac/manifest.json`: populate all 4 new fields
- `plugins/payments/manifest.json`: rename `flagsPassthrough` → `flags_passthrough` (schema-canonical snake_case)

## Verification

All three test gates pass locally:

- \`bash scripts/validate-manifests.sh\` → "All plugin manifests are valid."
- \`bash tests/test-build-index.sh\` → "OK"
- \`bash tests/test-schema-allowlist-coverage.sh\` → "OK (52 schema props ↔ 52 markers)"

## Rollback

Single revert PR. Schema additions are purely additive; reverting closes them.

## Why this PR exists separately from G2 (#84)

G2 #84 only touches the dispatch-sync workflow. Its CI fails because main is already red after #83. This hotfix unblocks #84 (and any other PR opened against main). Out of G2's locked scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)