### PR TITLE
feat(registry): categorize all 86 plugin manifests + CI gate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Validate all plugin manifests
         run: bash scripts/validate-manifests.sh
 
+      - name: Validate every plugin has a category assigned
+        run: bash scripts/categorize-manifests.sh --check
+
   validate-core-manifests:
     name: Validate core manifests against workflow plugins
     runs-on: ubuntu-latest

--- a/plugins/actors/manifest.json
+++ b/plugins/actors/manifest.json
@@ -26,5 +26,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "infrastructure"
 }

--- a/plugins/admin/manifest.json
+++ b/plugins/admin/manifest.json
@@ -55,5 +55,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-admin/releases/download/v1.0.0/workflow-plugin-admin-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "core"
 }

--- a/plugins/agent/manifest.json
+++ b/plugins/agent/manifest.json
@@ -11,7 +11,23 @@
   "minEngineVersion": "0.3.11",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-agent",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-agent",
-  "keywords": ["agent", "ai", "llm", "provider", "memory", "tools", "executor", "autonomous", "loop-detection", "orchestration", "mcp", "sse", "approvals", "jwt", "bcrypt"],
+  "keywords": [
+    "agent",
+    "ai",
+    "llm",
+    "provider",
+    "memory",
+    "tools",
+    "executor",
+    "autonomous",
+    "loop-detection",
+    "orchestration",
+    "mcp",
+    "sse",
+    "approvals",
+    "jwt",
+    "bcrypt"
+  ],
   "capabilities": {
     "moduleTypes": [
       "agent.provider",
@@ -45,5 +61,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "ai"
 }

--- a/plugins/ai/manifest.json
+++ b/plugins/ai/manifest.json
@@ -34,5 +34,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "ai"
 }

--- a/plugins/analytics/manifest.json
+++ b/plugins/analytics/manifest.json
@@ -64,5 +64,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-analytics/releases/download/v0.1.2/workflow-plugin-analytics-windows-amd64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "integrations"
 }

--- a/plugins/api/manifest.json
+++ b/plugins/api/manifest.json
@@ -35,5 +35,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/approval/manifest.json
+++ b/plugins/approval/manifest.json
@@ -32,5 +32,6 @@
     "triggerTypes": []
   },
   "downloads": [],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "core"
 }

--- a/plugins/audit-chain/manifest.json
+++ b/plugins/audit-chain/manifest.json
@@ -76,5 +76,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-audit-chain/releases/download/v0.2.4/workflow-plugin-audit-chain-windows-arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "security"
 }

--- a/plugins/audit/manifest.json
+++ b/plugins/audit/manifest.json
@@ -76,5 +76,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-audit/releases/download/v0.1.2/workflow-plugin-audit-windows-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "observability"
 }

--- a/plugins/auth/manifest.json
+++ b/plugins/auth/manifest.json
@@ -37,5 +37,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/authz-ui/manifest.json
+++ b/plugins/authz-ui/manifest.json
@@ -11,9 +11,20 @@
   "minEngineVersion": "0.2.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
-  "keywords": ["authz", "casbin", "ui", "policy", "rbac", "authorization", "react", "spa"],
+  "keywords": [
+    "authz",
+    "casbin",
+    "ui",
+    "policy",
+    "rbac",
+    "authorization",
+    "react",
+    "spa"
+  ],
   "capabilities": {
-    "moduleTypes": ["static.fileserver"],
+    "moduleTypes": [
+      "static.fileserver"
+    ],
     "stepTypes": [],
     "triggerTypes": [],
     "workflowHandlers": []
@@ -43,5 +54,6 @@
       "arch": "arm64",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
     }
-  ]
+  ],
+  "category": "core"
 }

--- a/plugins/authz/manifest.json
+++ b/plugins/authz/manifest.json
@@ -61,5 +61,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-authz/releases/download/v0.5.4/workflow-plugin-authz-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "core"
 }

--- a/plugins/aws/manifest.json
+++ b/plugins/aws/manifest.json
@@ -56,5 +56,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "infrastructure"
 }

--- a/plugins/azure/manifest.json
+++ b/plugins/azure/manifest.json
@@ -54,5 +54,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.0.0/workflow-plugin-azure-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "infrastructure"
 }

--- a/plugins/bento/manifest.json
+++ b/plugins/bento/manifest.json
@@ -72,5 +72,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-bento/releases/download/v1.1.3/workflow-plugin-bento-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "core"
 }

--- a/plugins/broker/manifest.json
+++ b/plugins/broker/manifest.json
@@ -21,5 +21,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "messaging"
 }

--- a/plugins/ci-generator/manifest.json
+++ b/plugins/ci-generator/manifest.json
@@ -58,5 +58,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-ci-generator/releases/download/v0.1.4/workflow-plugin-ci-generator-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "core"
 }

--- a/plugins/cicd/manifest.json
+++ b/plugins/cicd/manifest.json
@@ -68,5 +68,6 @@
   "status": "experimental",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/cloud-ui/manifest.json
+++ b/plugins/cloud-ui/manifest.json
@@ -11,9 +11,18 @@
   "minEngineVersion": "0.2.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-cloud-ui",
   "repository": "https://github.com/GoCodeAlone/workflow-cloud-ui",
-  "keywords": ["cloud", "ui", "dashboard", "management", "react", "spa"],
+  "keywords": [
+    "cloud",
+    "ui",
+    "dashboard",
+    "management",
+    "react",
+    "spa"
+  ],
   "capabilities": {
-    "moduleTypes": ["static.fileserver"],
+    "moduleTypes": [
+      "static.fileserver"
+    ],
     "stepTypes": [],
     "triggerTypes": [],
     "workflowHandlers": []
@@ -43,5 +52,6 @@
       "arch": "arm64",
       "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.1.0/workflow-cloud-ui-darwin-arm64.tar.gz"
     }
-  ]
+  ],
+  "category": "core"
 }

--- a/plugins/cloud/manifest.json
+++ b/plugins/cloud/manifest.json
@@ -20,5 +20,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "infrastructure"
 }

--- a/plugins/cms/manifest.json
+++ b/plugins/cms/manifest.json
@@ -31,5 +31,6 @@
     ],
     "triggerTypes": []
   },
-  "status": "experimental"
+  "status": "experimental",
+  "category": "core"
 }

--- a/plugins/configprovider/manifest.json
+++ b/plugins/configprovider/manifest.json
@@ -18,5 +18,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/crm/manifest.json
+++ b/plugins/crm/manifest.json
@@ -74,5 +74,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-crm/releases/download/v0.1.2/workflow-plugin-crm-windows-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/data-engineering/manifest.json
+++ b/plugins/data-engineering/manifest.json
@@ -155,5 +155,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-data-engineering/releases/download/v0.3.1/workflow-plugin-data-engineering-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "data"
 }

--- a/plugins/datadog/manifest.json
+++ b/plugins/datadog/manifest.json
@@ -174,5 +174,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-datadog/releases/download/v0.1.1/workflow-plugin-datadog-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "observability"
 }

--- a/plugins/datastores/manifest.json
+++ b/plugins/datastores/manifest.json
@@ -26,5 +26,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "data"
 }

--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -221,5 +221,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.11/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "infrastructure"
 }

--- a/plugins/discord/manifest.json
+++ b/plugins/discord/manifest.json
@@ -63,5 +63,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-discord/releases/download/v0.1.0/workflow-plugin-discord-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "messaging"
 }

--- a/plugins/dlq/manifest.json
+++ b/plugins/dlq/manifest.json
@@ -18,5 +18,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "messaging"
 }

--- a/plugins/erp/manifest.json
+++ b/plugins/erp/manifest.json
@@ -36,5 +36,6 @@
     "triggerTypes": []
   },
   "downloads": [],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/eventbus/manifest.json
+++ b/plugins/eventbus/manifest.json
@@ -73,5 +73,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-eventbus/releases/download/v0.3.5/workflow-plugin-eventbus-windows-arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "infrastructure"
 }

--- a/plugins/eventstore/manifest.json
+++ b/plugins/eventstore/manifest.json
@@ -18,5 +18,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "data"
 }

--- a/plugins/featureflags/manifest.json
+++ b/plugins/featureflags/manifest.json
@@ -30,5 +30,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "integrations"
 }

--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -52,5 +52,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.0.0/workflow-plugin-gcp-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "infrastructure"
 }

--- a/plugins/github/manifest.json
+++ b/plugins/github/manifest.json
@@ -89,5 +89,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-github/releases/download/v1.0.4/workflow-plugin-github-windows-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/gitlab/manifest.json
+++ b/plugins/gitlab/manifest.json
@@ -41,5 +41,6 @@
   "status": "experimental",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "integrations"
 }

--- a/plugins/hover/manifest.json
+++ b/plugins/hover/manifest.json
@@ -84,5 +84,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.2.8/workflow-plugin-hover-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "infrastructure"
 }

--- a/plugins/http/manifest.json
+++ b/plugins/http/manifest.json
@@ -54,5 +54,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/infra/manifest.json
+++ b/plugins/infra/manifest.json
@@ -33,5 +33,6 @@
   "status": "experimental",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/integration/manifest.json
+++ b/plugins/integration/manifest.json
@@ -27,5 +27,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "integrations"
 }

--- a/plugins/k8s/manifest.json
+++ b/plugins/k8s/manifest.json
@@ -16,5 +16,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "infrastructure"
 }

--- a/plugins/launchdarkly/manifest.json
+++ b/plugins/launchdarkly/manifest.json
@@ -155,5 +155,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly/releases/download/v0.1.1/workflow-plugin-launchdarkly-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/license/manifest.json
+++ b/plugins/license/manifest.json
@@ -20,5 +20,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/marketplace/manifest.json
+++ b/plugins/marketplace/manifest.json
@@ -25,5 +25,6 @@
   "status": "experimental",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/mcp/manifest.json
+++ b/plugins/mcp/manifest.json
@@ -24,5 +24,6 @@
   "status": "experimental",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "ai"
 }

--- a/plugins/messaging-core/manifest.json
+++ b/plugins/messaging-core/manifest.json
@@ -21,5 +21,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "core"
 }

--- a/plugins/messaging/manifest.json
+++ b/plugins/messaging/manifest.json
@@ -40,5 +40,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "messaging"
 }

--- a/plugins/modularcompat/manifest.json
+++ b/plugins/modularcompat/manifest.json
@@ -28,5 +28,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/monday/manifest.json
+++ b/plugins/monday/manifest.json
@@ -104,5 +104,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-monday/releases/download/v0.1.2/workflow-plugin-monday-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/namecheap/manifest.json
+++ b/plugins/namecheap/manifest.json
@@ -82,5 +82,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.0/workflow-plugin-namecheap-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "infrastructure"
 }

--- a/plugins/observability/manifest.json
+++ b/plugins/observability/manifest.json
@@ -47,5 +47,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "observability"
 }

--- a/plugins/okta/manifest.json
+++ b/plugins/okta/manifest.json
@@ -180,5 +180,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-okta/releases/download/v0.2.1/workflow-plugin-okta-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/openapi/manifest.json
+++ b/plugins/openapi/manifest.json
@@ -20,5 +20,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/openlms/manifest.json
+++ b/plugins/openlms/manifest.json
@@ -156,5 +156,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-openlms/releases/download/v0.1.2/workflow-plugin-openlms-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -57,5 +57,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-payments/releases/download/v0.4.6/workflow-plugin-payments-linux-arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "payments"
 }

--- a/plugins/pipelinesteps/manifest.json
+++ b/plugins/pipelinesteps/manifest.json
@@ -93,5 +93,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/platform/manifest.json
+++ b/plugins/platform/manifest.json
@@ -69,5 +69,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/policy/manifest.json
+++ b/plugins/policy/manifest.json
@@ -23,5 +23,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "security"
 }

--- a/plugins/ratchet/manifest.json
+++ b/plugins/ratchet/manifest.json
@@ -88,5 +88,6 @@
       "url": "https://github.com/GoCodeAlone/ratchet/releases/download/v1.0.0/ratchet-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "core"
 }

--- a/plugins/rooms/manifest.json
+++ b/plugins/rooms/manifest.json
@@ -21,5 +21,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "core"
 }

--- a/plugins/salesforce/manifest.json
+++ b/plugins/salesforce/manifest.json
@@ -126,5 +126,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-salesforce/releases/download/v0.2.2/workflow-plugin-salesforce-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/scanner/manifest.json
+++ b/plugins/scanner/manifest.json
@@ -18,5 +18,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "security"
 }

--- a/plugins/scheduler/manifest.json
+++ b/plugins/scheduler/manifest.json
@@ -29,5 +29,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/secrets/manifest.json
+++ b/plugins/secrets/manifest.json
@@ -31,5 +31,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "security"
 }

--- a/plugins/security-scanner/manifest.json
+++ b/plugins/security-scanner/manifest.json
@@ -20,5 +20,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "security"
 }

--- a/plugins/security/manifest.json
+++ b/plugins/security/manifest.json
@@ -11,7 +11,26 @@
   "minEngineVersion": "0.3.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-security",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-security",
-  "keywords": ["security", "waf", "coraza", "mfa", "totp", "encryption", "kms", "vault", "authz", "casbin", "rbac", "permit", "pii", "data-protection", "sandbox", "wasm", "supply-chain", "sbom"],
+  "keywords": [
+    "security",
+    "waf",
+    "coraza",
+    "mfa",
+    "totp",
+    "encryption",
+    "kms",
+    "vault",
+    "authz",
+    "casbin",
+    "rbac",
+    "permit",
+    "pii",
+    "data-protection",
+    "sandbox",
+    "wasm",
+    "supply-chain",
+    "sbom"
+  ],
   "capabilities": {
     "moduleTypes": [
       "security.waf",
@@ -100,5 +119,6 @@
       "arch": "arm64",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-darwin-arm64.tar.gz"
     }
-  ]
+  ],
+  "category": "security"
 }

--- a/plugins/slack/manifest.json
+++ b/plugins/slack/manifest.json
@@ -63,5 +63,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-slack/releases/download/v0.1.0/workflow-plugin-slack-linux-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "messaging"
 }

--- a/plugins/sso/manifest.json
+++ b/plugins/sso/manifest.json
@@ -31,5 +31,6 @@
     "triggerTypes": []
   },
   "downloads": [],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/statemachine/manifest.json
+++ b/plugins/statemachine/manifest.json
@@ -34,5 +34,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "core"
 }

--- a/plugins/steam/manifest.json
+++ b/plugins/steam/manifest.json
@@ -21,5 +21,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "integrations"
 }

--- a/plugins/storage/manifest.json
+++ b/plugins/storage/manifest.json
@@ -39,5 +39,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "data"
 }

--- a/plugins/teams/manifest.json
+++ b/plugins/teams/manifest.json
@@ -59,5 +59,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-teams/releases/download/v0.1.2/workflow-plugin-teams-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "integrations"
 }

--- a/plugins/template/manifest.json
+++ b/plugins/template/manifest.json
@@ -20,5 +20,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "core"
 }

--- a/plugins/timeline/manifest.json
+++ b/plugins/timeline/manifest.json
@@ -18,5 +18,6 @@
   "source": "github.com/GoCodeAlone/workflow",
   "tier": "core",
   "type": "builtin",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "category": "data"
 }

--- a/plugins/tofu/manifest.json
+++ b/plugins/tofu/manifest.json
@@ -76,5 +76,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-tofu/releases/download/v0.1.3/workflow-plugin-tofu-windows-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "infrastructure"
 }

--- a/plugins/turnio/manifest.json
+++ b/plugins/turnio/manifest.json
@@ -72,5 +72,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-turnio/releases/download/v0.1.1/workflow-plugin-turnio-darwin-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "messaging"
 }

--- a/plugins/twilio/manifest.json
+++ b/plugins/twilio/manifest.json
@@ -147,5 +147,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-twilio/releases/download/v0.2.0/workflow-plugin-twilio-linux-arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "messaging"
 }

--- a/plugins/vectorstore/manifest.json
+++ b/plugins/vectorstore/manifest.json
@@ -34,5 +34,6 @@
     "triggerTypes": []
   },
   "downloads": [],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "data"
 }

--- a/plugins/websocket/manifest.json
+++ b/plugins/websocket/manifest.json
@@ -36,5 +36,6 @@
     ],
     "workflowHandlers": []
   },
-  "status": "experimental"
+  "status": "experimental",
+  "category": "messaging"
 }

--- a/plugins/workflow-plugin-atlas-migrate/manifest.json
+++ b/plugins/workflow-plugin-atlas-migrate/manifest.json
@@ -175,5 +175,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-migrations/releases/download/v0.3.7/workflow-plugin-migrations-windows-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "data"
 }

--- a/plugins/workflow-plugin-auth/manifest.json
+++ b/plugins/workflow-plugin-auth/manifest.json
@@ -64,5 +64,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_darwin_arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "core"
 }

--- a/plugins/workflow-plugin-compute/manifest.json
+++ b/plugins/workflow-plugin-compute/manifest.json
@@ -49,5 +49,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.2/workflow-plugin-compute-darwin-arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "core"
 }

--- a/plugins/workflow-plugin-migrations/manifest.json
+++ b/plugins/workflow-plugin-migrations/manifest.json
@@ -175,5 +175,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-migrations/releases/download/v0.3.7/workflow-plugin-migrations-windows-arm64.tar.gz"
     }
   ],
-  "status": "experimental"
+  "status": "experimental",
+  "category": "data"
 }

--- a/plugins/workflow-plugin-product-capture/manifest.json
+++ b/plugins/workflow-plugin-product-capture/manifest.json
@@ -72,5 +72,6 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.1/workflow-plugin-product-capture-windows-arm64.tar.gz"
     }
   ],
-  "status": "verified"
+  "status": "verified",
+  "category": "core"
 }

--- a/plugins/workflow-plugin-supply-chain/manifest.json
+++ b/plugins/workflow-plugin-supply-chain/manifest.json
@@ -10,7 +10,18 @@
   "minEngineVersion": "0.18.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain",
-  "keywords": ["supply-chain", "security", "sbom", "vulnerability", "trivy", "grype", "cosign", "slsa", "syft", "sigstore"],
+  "keywords": [
+    "supply-chain",
+    "security",
+    "sbom",
+    "vulnerability",
+    "trivy",
+    "grype",
+    "cosign",
+    "slsa",
+    "syft",
+    "sigstore"
+  ],
   "capabilities": {
     "moduleTypes": [
       "security.plugin-verifier",
@@ -59,10 +70,22 @@
         "description": "Supply-chain verification and SBOM commands",
         "flags_passthrough": true,
         "subcommands": [
-          {"name": "scan",   "description": "Scan image with syft (OSV planned)"},
-          {"name": "verify", "description": "Verify cosign signature and SBOM"},
-          {"name": "sbom",   "description": "Generate CycloneDX SBOM"},
-          {"name": "report", "description": "Full supply-chain report"}
+          {
+            "name": "scan",
+            "description": "Scan image with syft (OSV planned)"
+          },
+          {
+            "name": "verify",
+            "description": "Verify cosign signature and SBOM"
+          },
+          {
+            "name": "sbom",
+            "description": "Generate CycloneDX SBOM"
+          },
+          {
+            "name": "report",
+            "description": "Full supply-chain report"
+          }
         ]
       },
       {
@@ -70,8 +93,14 @@
         "description": "Scaffold supply-chain config into app.yaml and CI",
         "flags_passthrough": true,
         "subcommands": [
-          {"name": "sbom", "description": "Add SBOM config to app.yaml + CI"},
-          {"name": "sign", "description": "Add signing config to app.yaml + CI"}
+          {
+            "name": "sbom",
+            "description": "Add SBOM config to app.yaml + CI"
+          },
+          {
+            "name": "sign",
+            "description": "Add signing config to app.yaml + CI"
+          }
         ]
       },
       {
@@ -79,7 +108,10 @@
         "description": "CI preflight and doctor commands",
         "flags_passthrough": true,
         "subcommands": [
-          {"name": "doctor", "description": "Run supply-chain preflight checks"}
+          {
+            "name": "doctor",
+            "description": "Run supply-chain preflight checks"
+          }
         ]
       }
     ]
@@ -109,5 +141,6 @@
       "arch": "arm64",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.3.0/workflow-plugin-supply-chain-darwin-arm64.tar.gz"
     }
-  ]
+  ],
+  "category": "security"
 }

--- a/plugins/ws-auth/manifest.json
+++ b/plugins/ws-auth/manifest.json
@@ -18,5 +18,6 @@
     ],
     "triggerTypes": [],
     "workflowHandlers": []
-  }
+  },
+  "category": "messaging"
 }

--- a/scripts/categorize-manifests.sh
+++ b/scripts/categorize-manifests.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# scripts/categorize-manifests.sh
+#
+# Assigns the `category` field to each plugin manifest under plugins/.
+# Source of truth: the explicit CATEGORY_MAP array below.
+#
+# Usage:
+#   --dry-run   Print what would change; exit non-zero if any plugin is unmapped.
+#   --apply     Write category into each manifest.json.
+#   --check     Read each manifest.json; exit non-zero if any has missing/null category.
+#               Used by CI (validate.yml) to enforce category coverage on every PR.
+#
+# The CATEGORY_MAP is the authoritative assignment for all 86 plugin dirs
+# as of 2026-05-21 (verified via `gh api repos/GoCodeAlone/workflow-registry/contents/plugins`).
+# New plugin dirs added without a MAP entry will cause --dry-run and --check to fail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+PLUGINS_DIR="${REPO_ROOT}/plugins"
+
+declare -A CATEGORY_MAP=(
+  [actors]="infrastructure"
+  [admin]="core"
+  [agent]="ai"
+  [ai]="ai"
+  [analytics]="integrations"
+  [api]="core"
+  [approval]="core"
+  [audit]="observability"
+  [audit-chain]="security"
+  [auth]="core"
+  [authz]="core"
+  [authz-ui]="core"
+  [aws]="infrastructure"
+  [azure]="infrastructure"
+  [bento]="core"
+  [broker]="messaging"
+  [ci-generator]="core"
+  [cicd]="core"
+  [cloud]="infrastructure"
+  [cloud-ui]="core"
+  [cms]="core"
+  [configprovider]="core"
+  [crm]="integrations"
+  [data-engineering]="data"
+  [datadog]="observability"
+  [datastores]="data"
+  [digitalocean]="infrastructure"
+  [discord]="messaging"
+  [dlq]="messaging"
+  [erp]="integrations"
+  [eventbus]="infrastructure"
+  [eventstore]="data"
+  [featureflags]="integrations"
+  [gcp]="infrastructure"
+  [github]="integrations"
+  [gitlab]="integrations"
+  [hover]="infrastructure"
+  [http]="core"
+  [infra]="core"
+  [integration]="integrations"
+  [k8s]="infrastructure"
+  [launchdarkly]="integrations"
+  [license]="core"
+  [marketplace]="core"
+  [mcp]="ai"
+  [messaging]="messaging"
+  [messaging-core]="core"
+  [modularcompat]="core"
+  [monday]="integrations"
+  [namecheap]="infrastructure"
+  [observability]="observability"
+  [okta]="integrations"
+  [openapi]="core"
+  [openlms]="integrations"
+  [payments]="payments"
+  [pipelinesteps]="core"
+  [platform]="core"
+  [policy]="security"
+  [ratchet]="core"
+  [rooms]="core"
+  [salesforce]="integrations"
+  [scanner]="security"
+  [scheduler]="core"
+  [secrets]="security"
+  [security]="security"
+  [security-scanner]="security"
+  [slack]="messaging"
+  [sso]="integrations"
+  [statemachine]="core"
+  [steam]="integrations"
+  [storage]="data"
+  [teams]="integrations"
+  [template]="core"
+  [timeline]="data"
+  [tofu]="infrastructure"
+  [turnio]="messaging"
+  [twilio]="messaging"
+  [vectorstore]="data"
+  [websocket]="messaging"
+  [workflow-plugin-atlas-migrate]="data"
+  [workflow-plugin-auth]="core"
+  [workflow-plugin-compute]="core"
+  [workflow-plugin-migrations]="data"
+  [workflow-plugin-product-capture]="core"
+  [workflow-plugin-supply-chain]="security"
+  [ws-auth]="messaging"
+)
+
+MODE="${1:-}"
+if [[ -z "${MODE}" ]]; then
+  echo "Usage: $0 [--dry-run|--apply|--check]" >&2
+  exit 1
+fi
+
+fail=0
+
+case "${MODE}" in
+  --dry-run)
+    echo "=== dry-run: showing category assignments ==="
+    while IFS= read -r manifest; do
+      plugin="$(basename "$(dirname "${manifest}")")"
+      cat="${CATEGORY_MAP[$plugin]:-}"
+      if [[ -z "${cat}" ]]; then
+        echo "  UNMAPPED: ${plugin} → add to CATEGORY_MAP in $0" >&2
+        fail=1
+      else
+        current="$(jq -r '.category // "null"' "${manifest}")"
+        if [[ "${current}" == "${cat}" ]]; then
+          echo "  OK (already set): ${plugin} → ${cat}"
+        else
+          echo "  WOULD SET: ${plugin} → ${cat} (currently: ${current})"
+        fi
+      fi
+    done < <(find "${PLUGINS_DIR}" -name "manifest.json" | sort)
+    if [[ "${fail}" -ne 0 ]]; then
+      echo "ERROR: unmapped plugins found. Add them to CATEGORY_MAP before running --apply." >&2
+      exit 1
+    fi
+    ;;
+
+  --apply)
+    echo "=== apply: writing category to manifests ==="
+    while IFS= read -r manifest; do
+      plugin="$(basename "$(dirname "${manifest}")")"
+      cat="${CATEGORY_MAP[$plugin]:-}"
+      if [[ -z "${cat}" ]]; then
+        echo "  SKIP UNMAPPED: ${plugin} — add to CATEGORY_MAP first" >&2
+        fail=1
+        continue
+      fi
+      # Use jq to add/update the category field (preserves all other fields).
+      tmp="$(mktemp)"
+      jq --arg cat "${cat}" '. + {category: $cat}' "${manifest}" > "${tmp}"
+      mv "${tmp}" "${manifest}"
+      echo "  SET: ${plugin} → ${cat}"
+    done < <(find "${PLUGINS_DIR}" -name "manifest.json" | sort)
+    if [[ "${fail}" -ne 0 ]]; then
+      echo "ERROR: some plugins were unmapped and skipped. Add them to CATEGORY_MAP." >&2
+      exit 1
+    fi
+    echo "Done."
+    ;;
+
+  --check)
+    echo "=== check: verifying all manifests have category assigned ==="
+    while IFS= read -r manifest; do
+      plugin="$(basename "$(dirname "${manifest}")")"
+      cat="$(jq -r '.category // empty' "${manifest}")"
+      if [[ -z "${cat}" ]]; then
+        echo "  FAIL: ${plugin} is missing category in manifest.json — run scripts/categorize-manifests.sh --apply or add to CATEGORY_MAP" >&2
+        fail=1
+      fi
+    done < <(find "${PLUGINS_DIR}" -name "manifest.json" | sort)
+    if [[ "${fail}" -ne 0 ]]; then
+      echo "ERROR: plugin(s) missing category. Add to CATEGORY_MAP and re-run --apply." >&2
+      exit 1
+    fi
+    echo "OK — all plugins have category assigned."
+    ;;
+
+  *)
+    echo "Unknown mode: ${MODE}" >&2
+    echo "Usage: $0 [--dry-run|--apply|--check]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `scripts/categorize-manifests.sh` with explicit 86-entry CATEGORY_MAP (--dry-run, --apply, --check modes)
- Sweeps all 86 plugin manifests with `--apply` (29 core, 15 integrations, 11 infrastructure, 9 messaging, 8 data, 7 security, 3 observability, 3 ai, 1 payments — zero null/other)
- Adds `validate.yml` CI gate: `bash scripts/categorize-manifests.sh --check` enforces category coverage on every future PR

**Depends on:** #98 (feat/category-schema must merge first — schema defines the category enum)

## Rollback
`git revert` removes all categorizations; index.json emits `category: null` per plugin.

## Part of
Dynamic plugin sync series (4 PRs): PR 2 of 4