### PR TITLE
feat(registry): strict-semver gate on upstream release tag (workflow#758 Layer 2)

### DIFF
--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -128,6 +128,16 @@ for manifest in "$PLUGINS_DIR"/*/manifest.json; do
     continue
   fi
 
+  # workflow#758: strict-semver gate. Reject plugins whose upstream release
+  # tag does not match the release-grade semver whitelist (engine ParseSemver
+  # requires flat vN.N.N — prerelease tags break downstream parsers). Catches
+  # plugins that bypass release.yml (manual upload, self-hosted runner,
+  # force-push). Same regex as `wfctl plugin validate-contract --for-publish`.
+  if [[ ! "$latest_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "  REJECT  $plugin_name — upstream release tag $latest_tag is not release-grade semver (engine ParseSemver requires flat M.m.p)"
+    continue
+  fi
+
   # Strip leading 'v' prefix
   latest_version="${latest_tag#v}"
 


### PR DESCRIPTION
## Summary

Defense-in-depth for workflow#758: registry's sync-versions.sh rejects any plugin whose upstream GitHub release tag is not release-grade semver (`^v\d+\.\d+\.\d+$`).

Catches plugins that bypass release.yml's pre-build gate (manual tarball upload, self-hosted runner, force-push) — same regex as workflow's `wfctl plugin validate-contract --for-publish` so both gates converge on the same input (the upstream tag string, not the manifest .version field).

Prerelease tags (`-rc.1`, `-feat-foo`, `+meta`) are rejected because engine `ParseSemver` is strict M.m.p — accepting them would let unparseable versions into the registry.

## Test plan

- [x] Inline regex verification: `v1.2.3` accepted; `v1.2.3-rc1`/`release-2026-05`/`v1.2` rejected
- [x] Existing sync flow unaffected for clean-semver plugins (DO at v2.0.16, AWS at vX.Y.Z, etc.)

## Rollback

Single revert. Catches misformatted tags as REJECT lines (continues processing other plugins) — no destructive action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)