### PR TITLE
chore(registry): sync workflow-plugin-auth manifest to v0.2.7 (#148, T-AUTH-11)

### DIFF
--- a/plugins/workflow-plugin-auth/manifest.json
+++ b/plugins/workflow-plugin-auth/manifest.json
@@ -1,15 +1,13 @@
 {
   "name": "workflow-plugin-auth",
-  "version": "0.1.4",
+  "version": "0.2.7",
   "description": "Passwordless authentication plugin: WebAuthn/passkeys, TOTP, email magic links",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",
   "tier": "core",
-  "private": true,
-  "minEngineVersion": "0.3.27",
-  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-auth",
-  "repository": "https://github.com/GoCodeAlone/workflow-plugin-auth",
+  "private": false,
+  "minEngineVersion": "0.57.2",
   "keywords": [
     "auth",
     "webauthn",
@@ -18,7 +16,62 @@
     "magic-link",
     "passwordless"
   ],
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-auth",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-auth",
+  "downloads": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.2.7/workflow-plugin-auth_0.2.7_linux_amd64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.2.7/workflow-plugin-auth_0.2.7_linux_arm64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.2.7/workflow-plugin-auth_0.2.7_darwin_amd64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.2.7/workflow-plugin-auth_0.2.7_darwin_arm64.tar.gz"
+    }
+  ],
+  "moduleTypes": [
+    "auth.credential"
+  ],
+  "stepTypes": [
+    "step.auth_passkey_begin_register",
+    "step.auth_passkey_finish_register",
+    "step.auth_passkey_begin_login",
+    "step.auth_passkey_finish_login",
+    "step.auth_totp_generate_secret",
+    "step.auth_totp_verify",
+    "step.auth_totp_recovery_codes",
+    "step.auth_magic_link_generate",
+    "step.auth_magic_link_verify",
+    "step.auth_magic_link_send",
+    "step.auth_password_hash",
+    "step.auth_password_verify",
+    "step.auth_challenge_generate",
+    "step.auth_challenge_verify",
+    "step.auth_normalize_phone",
+    "step.auth_methods_policy",
+    "step.auth_policy_gate",
+    "step.auth_methods_response",
+    "step.auth_policy_audit",
+    "step.auth_oauth_provider_config",
+    "step.auth_oauth_start",
+    "step.auth_oauth_exchange",
+    "step.auth_oauth_userinfo",
+    "step.auth_credential_list",
+    "step.auth_credential_revoke"
+  ],
   "capabilities": {
+    "configProvider": false,
     "moduleTypes": [
       "auth.credential"
     ],
@@ -33,37 +86,22 @@
       "step.auth_magic_link_generate",
       "step.auth_magic_link_verify",
       "step.auth_magic_link_send",
+      "step.auth_password_hash",
+      "step.auth_password_verify",
+      "step.auth_challenge_generate",
+      "step.auth_challenge_verify",
+      "step.auth_normalize_phone",
+      "step.auth_methods_policy",
+      "step.auth_policy_gate",
+      "step.auth_methods_response",
+      "step.auth_policy_audit",
+      "step.auth_oauth_provider_config",
+      "step.auth_oauth_start",
+      "step.auth_oauth_exchange",
+      "step.auth_oauth_userinfo",
       "step.auth_credential_list",
       "step.auth_credential_revoke"
     ],
     "triggerTypes": []
-  },
-  "assets": {
-    "ui": false,
-    "config": true
-  },
-  "downloads": [
-    {
-      "os": "linux",
-      "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_linux_amd64.tar.gz"
-    },
-    {
-      "os": "linux",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_linux_arm64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_darwin_amd64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth/releases/download/v0.1.4/workflow-plugin-auth_0.1.4_darwin_arm64.tar.gz"
-    }
-  ],
-  "status": "verified",
-  "category": "core"
+  }
 }


### PR DESCRIPTION
Resolves #148. Syncs manifest from workflow-plugin-auth@v0.2.7 plugin.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)