### PR TITLE
chore: sync private registry manifests

### DIFF
--- a/plugins/authz-ui/manifest.json
+++ b/plugins/authz-ui/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "authz-ui",
-  "version": "0.1.2",
+  "version": "1.0.3",
   "author": "GoCodeAlone",
   "description": "Casbin authorization policy management UI (React SPA)",
   "source": "github.com/GoCodeAlone/workflow-plugin-authz-ui",
@@ -8,7 +8,7 @@
   "tier": "premium",
   "license": "Proprietary",
   "private": true,
-  "minEngineVersion": "0.2.0",
+  "minEngineVersion": "0.53.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
   "keywords": [
@@ -22,12 +22,16 @@
     "spa"
   ],
   "capabilities": {
+    "configProvider": true,
     "moduleTypes": [
-      "static.fileserver"
+      "authz.ui"
     ],
-    "stepTypes": [],
-    "triggerTypes": [],
-    "workflowHandlers": []
+    "stepTypes": [
+      "step.authz_policy_check",
+      "step.authz_role_lookup",
+      "step.authz_enforce"
+    ],
+    "triggerTypes": []
   },
   "assets": {
     "ui": true,
@@ -35,24 +39,28 @@
   },
   "downloads": [
     {
-      "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-linux-amd64.tar.gz"
-    },
-    {
-      "os": "linux",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-linux-arm64.tar.gz"
-    },
-    {
       "os": "darwin",
+      "sha256": "071f731d1f4963ede34aea8e728912543817831748bc97fc6a85544dcedea75e",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "sha256": "b6046fef768382599e3a3034512e45c7b5b6ad213de59f736076674ad80463a4",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
+    },
+    {
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
+      "os": "linux",
+      "sha256": "cb1b4b2b99bc073e0403bec21ecbc4eed6c170bb86958614dc81076ff445814d",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-linux-amd64.tar.gz"
     },
     {
-      "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v0.1.2/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
+      "os": "linux",
+      "sha256": "62efed6c10169d38ef41c11e38718bf0c17bba45d768ff29ab9d8683807d2678",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-linux-arm64.tar.gz"
     }
   ],
   "category": "core"

--- a/plugins/cloud-ui/manifest.json
+++ b/plugins/cloud-ui/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-ui",
-  "version": "0.1.0",
+  "version": "0.2.8",
   "author": "GoCodeAlone",
   "description": "Cloud management UI plugin (React SPA)",
   "source": "github.com/GoCodeAlone/workflow-cloud-ui",
@@ -33,24 +33,28 @@
   },
   "downloads": [
     {
-      "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.1.0/workflow-cloud-ui-linux-amd64.tar.gz"
-    },
-    {
-      "os": "linux",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.1.0/workflow-cloud-ui-linux-arm64.tar.gz"
-    },
-    {
       "os": "darwin",
+      "sha256": "ada79d6752ae2f084ae6bff7074179c2337e1bfbd619bebcb289b4d0a6044cd6",
+      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.2.8/workflow-cloud-ui-darwin-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "sha256": "de6562db24975fea0a23676f04824eb77e8081993b428e14e40864e68756f0af",
+      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.2.8/workflow-cloud-ui-darwin-arm64.tar.gz"
+    },
+    {
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.1.0/workflow-cloud-ui-darwin-amd64.tar.gz"
+      "os": "linux",
+      "sha256": "0c719b91a5fb1cdcf104861a8ad5b14c40070220f0f7fe18d14fdf4db850053e",
+      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.2.8/workflow-cloud-ui-linux-amd64.tar.gz"
     },
     {
-      "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.1.0/workflow-cloud-ui-darwin-arm64.tar.gz"
+      "os": "linux",
+      "sha256": "f303530d8aaf3c3f8e7184501307661d2242385f5517f31ff28213ff0fc7b9b1",
+      "url": "https://github.com/GoCodeAlone/workflow-cloud-ui/releases/download/v0.2.8/workflow-cloud-ui-linux-arm64.tar.gz"
     }
   ],
   "category": "core"

--- a/plugins/security/manifest.json
+++ b/plugins/security/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "security",
-  "version": "0.2.2",
+  "version": "2.0.3",
   "author": "GoCodeAlone",
   "description": "Unified security plugin: WAF (Coraza/AWS/GCloud/Cloudflare), MFA/encryption (TOTP, AES-256-GCM, AWS KMS, GCP KMS, Vault Transit), authorization (Casbin RBAC, Permit.io), data protection (PII detection/masking), sandbox (WASM/wazero, Docker), and supply-chain security (signatures, vuln scanning, SBOM)",
   "source": "github.com/GoCodeAlone/workflow-plugin-security",
@@ -8,7 +8,7 @@
   "tier": "premium",
   "license": "Proprietary",
   "private": true,
-  "minEngineVersion": "0.3.0",
+  "minEngineVersion": "0.53.0",
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-security",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-security",
   "keywords": [
@@ -32,6 +32,7 @@
     "sbom"
   ],
   "capabilities": {
+    "configProvider": false,
     "moduleTypes": [
       "security.waf",
       "security.waf.aws",
@@ -91,8 +92,7 @@
       "step.sbom_generate",
       "step.sbom_check"
     ],
-    "triggerTypes": [],
-    "workflowHandlers": []
+    "triggerTypes": []
   },
   "assets": {
     "ui": false,
@@ -100,24 +100,28 @@
   },
   "downloads": [
     {
-      "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-linux-amd64.tar.gz"
-    },
-    {
-      "os": "linux",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-linux-arm64.tar.gz"
-    },
-    {
       "os": "darwin",
+      "sha256": "be097b3079b0a166acdda02e64697373d0c680328a9316f51d059dcbbc6e7dd7",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.3/workflow-plugin-security-darwin-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "sha256": "b35fb4c80b51775bc020c858a82de4b92791f3357fb3cca8d76630a083c016eb",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.3/workflow-plugin-security-darwin-arm64.tar.gz"
+    },
+    {
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-darwin-amd64.tar.gz"
+      "os": "linux",
+      "sha256": "ccbca3de9b94e738155a8c61bea8250dc7e442af080232b2d0969b30fe908fc3",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.3/workflow-plugin-security-linux-amd64.tar.gz"
     },
     {
-      "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v0.2.2/workflow-plugin-security-darwin-arm64.tar.gz"
+      "os": "linux",
+      "sha256": "90e3ad6851a9502c6a7d7acc92a208dca54babadbb140571464597b0c38ccb7f",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-security/releases/download/v2.0.3/workflow-plugin-security-linux-arm64.tar.gz"
     }
   ],
   "category": "security"


### PR DESCRIPTION
Post-merge registry drift check after #155 found remaining private/premium manifest updates for authz-ui, cloud-ui, and security.\n\nValidation run locally:\n- AJV="npx --yes ajv-cli" bash scripts/validate-manifests.sh\n- bash scripts/categorize-manifests.sh --check\n- WORKFLOW_REPO=/Users/jon/workspace/workflow bash scripts/sync-core-manifests.sh\n- bash scripts/generate-readme.sh --check\n- bash scripts/validate-templates.sh\n- bash tests/test-build-index.sh\n- bash tests/test-schema-allowlist-coverage.sh