### PR TITLE
ci: bound registry sync PR backlog

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -371,6 +371,11 @@ jobs:
               git push origin "${BRANCH}"
               # Update PR title/body to match the post-re-sync version.
               gh pr edit "${existing}" --title "${NEW_TITLE}" --body "${NEW_BODY}"
+              if [[ -n "${PLUGIN}" ]]; then
+                scripts/reconcile-sync-prs.sh --current-pr "${existing}" --mode plugin --plugin "${PLUGIN}"
+              else
+                scripts/reconcile-sync-prs.sh --current-pr "${existing}" --mode full
+              fi
               echo "appended sync commit to PR #${existing} (post-re-sync metadata refreshed)"
               exit 0
             fi
@@ -388,4 +393,10 @@ jobs:
           git add plugins/ README.md
           git commit -m "${TITLE}"
           git push origin "${BRANCH}"
-          gh pr create --base main --head "${BRANCH}" --title "${TITLE}" --body "${BODY}"
+          pr_url="$(gh pr create --base main --head "${BRANCH}" --title "${TITLE}" --body "${BODY}")"
+          pr_number="${pr_url##*/}"
+          if [[ -n "${PLUGIN}" ]]; then
+            scripts/reconcile-sync-prs.sh --current-pr "${pr_number}" --mode plugin --plugin "${PLUGIN}"
+          else
+            scripts/reconcile-sync-prs.sh --current-pr "${pr_number}" --mode full
+          fi

--- a/scripts/reconcile-sync-prs.sh
+++ b/scripts/reconcile-sync-prs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Close superseded bot-created registry sync PRs.
+
+set -euo pipefail
+
+REPO="GoCodeAlone/workflow-registry"
+CURRENT_PR=""
+MODE=""
+PLUGIN=""
+DRY_RUN=false
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/reconcile-sync-prs.sh --current-pr <number> --mode full|plugin [--plugin <name>] [--dry-run]
+
+Modes:
+  full    close older bot sync PRs for any plugin/full-registry sync
+  plugin  close older bot sync PRs for the same plugin only
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --current-pr)
+      shift
+      CURRENT_PR="${1:-}"
+      ;;
+    --mode)
+      shift
+      MODE="${1:-}"
+      ;;
+    --plugin)
+      shift
+      PLUGIN="${1:-}"
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$CURRENT_PR" || -z "$MODE" ]]; then
+  usage
+  exit 2
+fi
+
+case "$MODE" in
+  full) ;;
+  plugin)
+    if [[ -z "$PLUGIN" ]]; then
+      echo "--plugin is required when --mode plugin" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "--mode must be full or plugin" >&2
+    exit 2
+    ;;
+esac
+
+prs_json="$(gh pr list --repo "$REPO" --state open --limit 100 \
+  --json number,title,author,headRefName,url)"
+
+if [[ "$MODE" == "full" ]]; then
+  candidates="$(jq -r --argjson current "$CURRENT_PR" '
+    .[]
+    | select(.number != $current)
+    | select(.author.login == "app/github-actions" or .author.login == "github-actions[bot]")
+    | select(.headRefName | startswith("chore/sync-"))
+    | [.number, .headRefName, .title] | @tsv
+  ' <<<"$prs_json")"
+else
+  candidates="$(jq -r --argjson current "$CURRENT_PR" --arg plugin "$PLUGIN" '
+    .[]
+    | select(.number != $current)
+    | select(.author.login == "app/github-actions" or .author.login == "github-actions[bot]")
+    | select(.headRefName | startswith("chore/sync-" + $plugin + "-"))
+    | [.number, .headRefName, .title] | @tsv
+  ' <<<"$prs_json")"
+fi
+
+if [[ -z "$candidates" ]]; then
+  echo "reconcile-sync-prs: no superseded sync PRs found"
+  exit 0
+fi
+
+while IFS=$'\t' read -r pr branch title; do
+  [[ -n "$pr" ]] || continue
+  echo "reconcile-sync-prs: superseded #$pr ($branch) $title"
+  if $DRY_RUN; then
+    continue
+  fi
+  gh pr comment "$pr" --repo "$REPO" \
+    --body "Closed as superseded by registry sync PR #${CURRENT_PR}. The newer sync PR covers this generated manifest update."
+  gh pr close "$pr" --repo "$REPO" --delete-branch
+done <<<"$candidates"

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -99,6 +99,90 @@ fetch_plugin_json() {
   gh api "repos/$gh_repo/contents/plugin.json?ref=$tag" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true
 }
 
+normalize_plugin_json_for_registry() {
+  local plugin_name="$1"
+  jq -c --arg plugin "$plugin_name" '
+    def clean_iac_provider:
+      if . == null then null
+      else {
+        name: .name,
+        resourceTypes: .resourceTypes,
+        computePlanVersion: .computePlanVersion
+      } | with_entries(select(.value != null))
+      end;
+
+    def clean_capability_iac_provider:
+      if . == null then null
+      else {
+        name: .name,
+        resourceTypes: .resourceTypes,
+        supportedCanonicalKeys: .supportedCanonicalKeys,
+        configSchema: .configSchema
+      } | with_entries(select(.value != null))
+      end;
+
+    def provider_name($caps):
+      (
+        $caps.iacProvider.name?
+        // .iacProvider.name?
+        // (($caps.moduleTypes // [])[]? | select(startswith("iac.provider.")) | sub("^iac.provider\\."; ""))
+        // ($plugin | sub("^workflow-plugin-"; ""))
+      );
+
+    def clean_cli_commands:
+      [
+        .[]? |
+        {
+          name: .name,
+          description: .description,
+          flags_passthrough: (
+            if has("flags_passthrough") then .flags_passthrough
+            elif has("flagsPassthrough") then .flagsPassthrough
+            else null
+            end
+          ),
+          subcommands: (
+            if .subcommands == null then null
+            else [.subcommands[]? | {name: .name, description: .description} | with_entries(select(.value != null))]
+            end
+          )
+        } | with_entries(select(.value != null))
+      ];
+
+    def clean_capabilities:
+      (.capabilities // {}) as $caps |
+      {}
+      + (if $caps.configProvider != null then {configProvider: $caps.configProvider} else {} end)
+      + (if $caps.moduleTypes != null then {moduleTypes: $caps.moduleTypes} else {} end)
+      + (if $caps.stepTypes != null then {stepTypes: $caps.stepTypes} else {} end)
+      + (if $caps.triggerTypes != null then {triggerTypes: $caps.triggerTypes} else {} end)
+      + (if $caps.workflowHandlers != null then {workflowHandlers: $caps.workflowHandlers} else {} end)
+      + (if $caps.wiringHooks != null then {wiringHooks: $caps.wiringHooks} else {} end)
+      + (if $caps.migrationDrivers != null then {migrationDrivers: $caps.migrationDrivers} else {} end)
+      + (if $caps.iacStateBackends != null then {iacStateBackends: $caps.iacStateBackends} else {} end)
+      + (if $caps.serviceMethods != null then {serviceMethods: $caps.serviceMethods} else {} end)
+      + (if $caps.buildHooks != null then {buildHooks: $caps.buildHooks} else {} end)
+      + (if $caps.cliCommands != null then {cliCommands: ($caps.cliCommands | clean_cli_commands)} else {} end)
+      + (
+          if $caps.iacProvider != null or $caps.resourceTypes != null then
+            {
+              iacProvider: (
+                (($caps.iacProvider // {}) | clean_capability_iac_provider // {})
+                + (if $caps.resourceTypes != null then {name: provider_name($caps), resourceTypes: $caps.resourceTypes} else {} end)
+              )
+            }
+          else {}
+          end
+        );
+
+    {
+      capabilities: (clean_capabilities | if . == {} then null else . end),
+      minEngineVersion: (.minEngineVersion // null),
+      iacProvider: (.iacProvider | clean_iac_provider)
+    }
+  '
+}
+
 mismatches=0
 
 for manifest in "$PLUGINS_DIR"/*/manifest.json; do
@@ -198,11 +282,7 @@ for manifest in "$PLUGINS_DIR"/*/manifest.json; do
       caps_synced=""
       if [[ -n "$plugin_json" ]]; then
         tmp_caps="$(mktemp)"
-        echo "$plugin_json" | jq -c '{
-          capabilities: (.capabilities // null),
-          minEngineVersion: (.minEngineVersion // null),
-          iacProvider: (.iacProvider // null)
-        }' > "$tmp_caps" 2>/dev/null || true
+        echo "$plugin_json" | normalize_plugin_json_for_registry "$plugin_name" > "$tmp_caps" 2>/dev/null || true
         if [[ -s "$tmp_caps" ]]; then
           tmp2="$(mktemp)"
           jq --slurpfile src "$tmp_caps" '


### PR DESCRIPTION
## Summary
- close superseded registry sync PRs automatically after the sync workflow creates or appends to a canonical PR
- normalize upstream plugin metadata before writing registry manifests so sync output stays schema-compatible
- add a dry-runnable reconciliation helper for full and per-plugin sync modes

## Validation
- bash -n scripts/sync-versions.sh
- bash -n scripts/reconcile-sync-prs.sh
- bash scripts/reconcile-sync-prs.sh --current-pr 160 --mode full --dry-run
- git diff --check
- AJV="npx --yes ajv-cli" bash scripts/validate-manifests.sh
- bash scripts/categorize-manifests.sh --check
- WORKFLOW_REPO=/Users/jon/workspace/workflow bash scripts/sync-core-manifests.sh
- bash scripts/generate-readme.sh --check
- bash scripts/validate-templates.sh
- bash tests/test-build-index.sh
- bash tests/test-schema-allowlist-coverage.sh

Part of the locked governance supersession / workflow-registry backlog reconciliation plan.