### PR TITLE
chore(manifest): pin-bump 4 DNS providers for EnumerateAll cascade (+ cloudflare CREATE)

### DIFF
--- a/plugins/cloudflare/manifest.json
+++ b/plugins/cloudflare/manifest.json
@@ -1,0 +1,76 @@
+{
+  "name": "workflow-plugin-cloudflare",
+  "version": "0.1.1",
+  "minEngineVersion": "0.60.8",
+  "description": "Cloudflare DNS provider for workflow IaC (infra.dns)",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare",
+  "keywords": [
+    "cloudflare",
+    "dns",
+    "iac",
+    "infra.dns"
+  ],
+  "capabilities": {
+    "moduleTypes": [
+      "iac.provider.cloudflare"
+    ],
+    "stepTypes": [],
+    "triggerTypes": [],
+    "iacProvider": {
+      "name": "cloudflare",
+      "resourceTypes": [
+        "infra.dns",
+        "infra.domain"
+      ]
+    }
+  },
+  "required_secrets": [
+    {
+      "name": "CLOUDFLARE_API_TOKEN",
+      "sensitive": true,
+      "description": "Cloudflare API token with Zone:Read and DNS:Edit for managed zones; registrar import/status also requires Registrar read access and auto-renew updates require Registrar edit access.",
+      "prompt": "Cloudflare API token"
+    }
+  ],
+  "iacProvider": {
+    "computePlanVersion": "v2"
+  },
+  "assets": {
+    "ui": false,
+    "config": true
+  },
+  "downloads": [
+    {
+      "arch": "amd64",
+      "os": "darwin",
+      "sha256": "9683cb47c4921abb5065372be345ba95e027a306c9691053f8e2fe70ba7776bd",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.1/workflow-plugin-cloudflare-darwin-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "sha256": "08eb4c0d4f68f46a417641224a120fc88bd1a3c041e4ece313529933b946e616",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.1/workflow-plugin-cloudflare-darwin-arm64.tar.gz"
+    },
+    {
+      "arch": "amd64",
+      "os": "linux",
+      "sha256": "fa0685bac1ceffe485df5851a072a34fce9db65166c3d9cd8c2f9637eb1d2329",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.1/workflow-plugin-cloudflare-linux-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "linux",
+      "sha256": "4903431615f625fbef8f1a76bbc15855b9a80ffb1592187db1f9078d238dd7fe",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.1/workflow-plugin-cloudflare-linux-arm64.tar.gz"
+    }
+  ],
+  "status": "experimental",
+  "category": "infrastructure"
+}

--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "minEngineVersion": "0.64.3",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage Volumes, IAM, and API gateway",
   "author": "GoCodeAlone",
@@ -199,26 +199,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "f20de5691f42d43f90517cefb4d7130629109754fb001ce409fcabcdbe5fa247",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.5/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "sha256": "c5fb31af60a3fade413c47aa480b82d6102bced604cd374709248d35df9e57f1",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "3600153cfef79dd957391953d4e14ef88731eb01498429f53c60567be8dacc36",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.5/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "sha256": "5e01d58aef83e40107521802afbdd8fb4d7cb1d3b0a4adb46fe24ad991b386ca",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "9424bfcf720c8509e4ecbdc214fc30b874ff8ae4b51170cbfcbadf228564e497",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.5/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "sha256": "2ead2dc9fa9c8a09abc735e741e0f0efe3303edd586ac22a4ec80bba11ab62e5",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "7ba71a5230dcd3252ab936a6b41e82f78a68ac508a2672ff8a15cf45298939c3",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.5/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "sha256": "b837b9e3aa9e869d98a530d6f74c44b53cdffcbde2809d8c8de437251bad1da6",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     }
   ],
   "status": "verified",

--- a/plugins/hover/manifest.json
+++ b/plugins/hover/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-hover",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "minEngineVersion": "0.60.6",
   "description": "Hover DNS provider for workflow IaC (infra.dns). No official API; mimics the browser-side username+password+TOTP login flow used by pjslauta/hover-dyn-dns.",
   "author": "GoCodeAlone",
@@ -62,26 +62,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "497fd59f265867157b9b4efc597dfbb0ad0556ba5125bba26f5fe7a82ea5d5b4",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.3.0/workflow-plugin-hover-darwin-amd64.tar.gz"
+      "sha256": "4b90a1821a3eb3020040d93b281ffbf2652530a2ef0450ea5fc9af9633f56edc",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.4.0/workflow-plugin-hover-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "95893ffec47f7d4ede7e0a34aca5ec08274476020ae309dc28b6458539748d9a",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.3.0/workflow-plugin-hover-darwin-arm64.tar.gz"
+      "sha256": "7fe781ff8576c77eeb55ec1b7d807bd20b7876e47202ca2c86fec62bd39fdae8",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.4.0/workflow-plugin-hover-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "ed28c878759bef1ade16acbe5025c4afba8ceadf18409ed0703148e59b1d2ee7",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.3.0/workflow-plugin-hover-linux-amd64.tar.gz"
+      "sha256": "26ab015958163b7a60352466458ad809c40eaf404d99c1e7a8e122c6cda79382",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.4.0/workflow-plugin-hover-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "56b83c67f082df2b30cb4296afe579326816ca174439dd5ba96139aee5c834b0",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.3.0/workflow-plugin-hover-linux-arm64.tar.gz"
+      "sha256": "b653fe47724b7125900295c3846db388999a5a6dfa25cec12322cb3b67cb72ba",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.4.0/workflow-plugin-hover-linux-arm64.tar.gz"
     }
   ],
   "status": "experimental",

--- a/plugins/namecheap/manifest.json
+++ b/plugins/namecheap/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-namecheap",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "minEngineVersion": "0.60.6",
   "description": "Namecheap DNS provider for workflow IaC (infra.dns) backed by the official go-namecheap-sdk.",
   "author": "GoCodeAlone",
@@ -61,26 +61,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "9d75652e1cca3a8efc069e387105f1e68e3efa686e99590c8d434862b24fa252",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.2/workflow-plugin-namecheap-darwin-amd64.tar.gz"
+      "sha256": "5d16c7ec0bba52a1095b20761faefb1349e279a8c2d76e19d522344d83c30259",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.4/workflow-plugin-namecheap-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "c69b5f4c4e3c8b503ed1be55704316c2e5dffdafbe8b8ddd6abe44f3adf5f42c",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.2/workflow-plugin-namecheap-darwin-arm64.tar.gz"
+      "sha256": "62c7f37ab470e8f24a30b24f83ea1035a0302c30218cc2c34d11194724dfcb04",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.4/workflow-plugin-namecheap-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "d609ee80ac8e6dcf063c6f727762743e28ae4abff7f35c91363a6117c8f6d1db",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.2/workflow-plugin-namecheap-linux-amd64.tar.gz"
+      "sha256": "e31090e0f1137854281c092737bc3e9c5515d762b6f448dce266fad2e1b1033a",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.4/workflow-plugin-namecheap-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "844ae99e3e80ebaf6a99657f6d72b143077649465b06df39d2cf7c9c92a10442",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.2/workflow-plugin-namecheap-linux-arm64.tar.gz"
+      "sha256": "36fc1ffeda4b3ba1af69d010a487b2862df9b3ec2345cb51806422485302f123",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.4/workflow-plugin-namecheap-linux-arm64.tar.gz"
     }
   ],
   "status": "experimental",


### PR DESCRIPTION
## Summary

Pin-bumps four DNS-provider manifests after the EnumerateAll(\"infra.dns\") cascade lands in the four provider repos:

| Plugin | Old version | New version |
|---|---|---|
| digitalocean | v2.1.5 | **v2.1.6** |
| hover | v0.3.0 | **v0.4.0** |
| namecheap | v0.1.2 | **v0.1.4** (skips broken v0.1.3) |
| cloudflare | — (NEW) | **v0.1.1** (skips broken v0.1.0) |

Cloudflare had no manifest in this registry before — this PR creates one, mirroring the Hover layout (DNS-only IaC provider).

## Why v0.1.4 / v0.1.1 instead of v0.1.3 / v0.1.0

The v0.1.3 (NC) and v0.1.0 (CF) tags exist but their Release workflows failed `wfctl plugin verify-capabilities` with:
\`\`\`
binary Manifest.Name=\"\"
\`\`\`
Neither plugin's \`main.go\` embedded \`plugin.json\` via \`sdk.MustEmbedManifest\`, so the runtime truth-check rejected the artifact. Backport fixes (workflow-plugin-namecheap#15, workflow-plugin-cloudflare#10) added the ManifestProvider option and re-tagged at v0.1.4 / v0.1.1.

## Verification

- \`scripts/validate-manifests.sh\` — all 4 manifests valid.
- \`scripts/sync-versions.sh\` — all manifest versions in sync; SHA-256s for DO/Hover/NC captured via \`--fix\`; CF SHA-256s captured via direct curl + shasum.

## Part of cross-repo cascade

\`docs/plans/2026-05-26-dns-provider-contract.md\` (workflow-plugin-infra). PR 5 of 9. Unblocks PR 6 (\`wfctl infra import-all\`) which type-asserts \`IaCProviderEnumerator\` on the loaded plugin and requires the registry to advertise the new tags before its e2e smoke test can run against a real provider plugin.

## Test plan

- [x] \`scripts/validate-manifests.sh\` passes
- [x] \`scripts/sync-versions.sh\` reports all in sync
- [ ] Admin-merge in same turn per \`feedback_version_bump_immediate_merge.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)