### PR TITLE
chore(registry): sync digitalocean v2.1.7 — required_secrets + downloads (PR7/7)

### DIFF
--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -1,7 +1,15 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "minEngineVersion": "0.64.3",
+  "required_secrets": [
+    {
+      "name": "DIGITALOCEAN_TOKEN",
+      "sensitive": true,
+      "description": "DigitalOcean API token with read/write scope (DNS + infra via godo).",
+      "prompt": "DigitalOcean API token"
+    }
+  ],
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage Volumes, IAM, and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -141,7 +149,7 @@
           }
         },
         "infra.firewall": {
-          "description": "DigitalOcean cloud firewall. Attaches to Droplets by ID or by tag (which auto-attaches future Droplets / DOKS pools that receive the tag). Either `droplet_ids` or `tags` is REQUIRED; `wfctl infra apply` rejects firewalls with no targets before any DO API call. NOTE: DO firewalls do not attach to App Platform apps — for App-Platform-only deployments, use `expose: internal` services plus `trusted_sources` on managed databases.",
+          "description": "DigitalOcean cloud firewall. Attaches to Droplets by ID or by tag (which auto-attaches future Droplets / DOKS pools that receive the tag). Either `droplet_ids` or `tags` is REQUIRED; `wfctl infra apply` rejects firewalls with no targets before any DO API call. NOTE: DO firewalls do not attach to App Platform apps \u2014 for App-Platform-only deployments, use `expose: internal` services plus `trusted_sources` on managed databases.",
           "fields": {
             "droplet_ids": {
               "type": "array<int>",
@@ -199,26 +207,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "c5fb31af60a3fade413c47aa480b82d6102bced604cd374709248d35df9e57f1",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "sha256": "d5430c3bcf2f9f7e1959d06a311741252dc1378fcab63593dbfb8b65aeb8743d",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.7/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "5e01d58aef83e40107521802afbdd8fb4d7cb1d3b0a4adb46fe24ad991b386ca",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "sha256": "9b22be0b7566e18ce11dbd978e0ecb93ca84fd1409182d8542fdf150796c6deb",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.7/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "2ead2dc9fa9c8a09abc735e741e0f0efe3303edd586ac22a4ec80bba11ab62e5",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "sha256": "f7f2eb3e768f1c3045b7a7df647a6c4ca34826dff27c509030db557cdb367330",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.7/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "b837b9e3aa9e869d98a530d6f74c44b53cdffcbde2809d8c8de437251bad1da6",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.6/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "sha256": "729bedbf3c8d4961c44a2564d553413ed62e52a8eaa4a716f1f9a768e6e98260",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.1.7/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     }
   ],
   "status": "verified",


### PR DESCRIPTION
## What

PR7 of the **wfctl secrets wizard + smart CI** cascade. Syncs the DigitalOcean registry manifest to v2.1.7 so `wfctl secrets setup --plugin digitalocean` provisions `DIGITALOCEAN_TOKEN` uniformly with cloudflare/namecheap/hover.

The plugin side already shipped: `workflow-plugin-digitalocean` PR #178 advertised `required_secrets[]` (DIGITALOCEAN_TOKEN), released in **v2.1.7**. This PR mirrors that into the authoritative registry manifest (the registry was stale at v2.1.6 without the secrets block).

### Changes
- `plugins/digitalocean/manifest.json`: version `2.1.6` → `2.1.7`; added `required_secrets: [DIGITALOCEAN_TOKEN]` (mirrors plugin.json); repointed all 4 `downloads[].url` to the v2.1.7 release + updated each `sha256` to the v2.1.7 asset checksums.

## Verification
- `bash scripts/validate-manifests.sh` → `plugins/digitalocean/manifest.json valid` (the version/download-tag invariant passes; sha256 match the real v2.1.7 release assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)