### PR TITLE
chore(registry): required_secrets for tier-1 plugins (cloud+payments+comms)

### DIFF
--- a/plugins/aws/manifest.json
+++ b/plugins/aws/manifest.json
@@ -8,6 +8,20 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.64.3",
+  "required_secrets": [
+    {
+      "name": "AWS_ACCESS_KEY_ID",
+      "sensitive": true,
+      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID} in the iac.provider/aws config.",
+      "prompt": "AWS access key ID"
+    },
+    {
+      "name": "AWS_SECRET_ACCESS_KEY",
+      "sensitive": true,
+      "description": "AWS secret access key (pairs with AWS_ACCESS_KEY_ID). Referenced as ${AWS_SECRET_ACCESS_KEY}.",
+      "prompt": "AWS secret access key"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-aws",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-aws",
   "keywords": [

--- a/plugins/azure/manifest.json
+++ b/plugins/azure/manifest.json
@@ -8,6 +8,32 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.64.3",
+  "required_secrets": [
+    {
+      "name": "AZURE_CLIENT_ID",
+      "sensitive": false,
+      "description": "Azure AD app (service principal) client ID for DefaultAzureCredential. Referenced as ${AZURE_CLIENT_ID}.",
+      "prompt": "Azure client ID"
+    },
+    {
+      "name": "AZURE_CLIENT_SECRET",
+      "sensitive": true,
+      "description": "Azure AD app client secret. Referenced as ${AZURE_CLIENT_SECRET}.",
+      "prompt": "Azure client secret"
+    },
+    {
+      "name": "AZURE_TENANT_ID",
+      "sensitive": false,
+      "description": "Azure AD tenant ID. Referenced as ${AZURE_TENANT_ID}.",
+      "prompt": "Azure tenant ID"
+    },
+    {
+      "name": "AZURE_SUBSCRIPTION_ID",
+      "sensitive": false,
+      "description": "Azure subscription ID for IaC operations. Referenced as ${AZURE_SUBSCRIPTION_ID}.",
+      "prompt": "Azure subscription ID"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-azure",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-azure",
   "keywords": [

--- a/plugins/discord/manifest.json
+++ b/plugins/discord/manifest.json
@@ -8,6 +8,14 @@
   "tier": "community",
   "license": "MIT",
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "DISCORD_BOT_TOKEN",
+      "sensitive": true,
+      "description": "Discord bot token. Referenced as ${DISCORD_BOT_TOKEN} in the provider token config.",
+      "prompt": "Discord bot token"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-discord",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-discord",
   "keywords": [

--- a/plugins/github/manifest.json
+++ b/plugins/github/manifest.json
@@ -8,6 +8,14 @@
   "tier": "core",
   "license": "MIT",
   "minEngineVersion": "0.61.0",
+  "required_secrets": [
+    {
+      "name": "GITHUB_APP_PRIVATE_KEY",
+      "sensitive": true,
+      "description": "GitHub App private key (PEM) for the github.app module. Referenced as ${GITHUB_APP_PRIVATE_KEY} in private_key. (Step-level operations may also use a GITHUB_TOKEN.)",
+      "prompt": "GitHub App private key (PEM)"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-github",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-github",
   "keywords": [

--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -8,6 +8,20 @@
   "tier": "core",
   "private": false,
   "minEngineVersion": "0.53.0",
+  "required_secrets": [
+    {
+      "name": "STRIPE_SECRET_KEY",
+      "sensitive": true,
+      "description": "Stripe secret API key (provider: stripe). PayPal deployments instead provision PAYPAL_CLIENT_ID + PAYPAL_CLIENT_SECRET. Referenced as ${STRIPE_SECRET_KEY}.",
+      "prompt": "Stripe secret key"
+    },
+    {
+      "name": "STRIPE_WEBHOOK_SECRET",
+      "sensitive": true,
+      "description": "Stripe webhook signing secret; required for step.payment_webhook_verify. Referenced as ${STRIPE_WEBHOOK_SECRET}.",
+      "prompt": "Stripe webhook signing secret"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-payments",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-payments",
   "keywords": [

--- a/plugins/slack/manifest.json
+++ b/plugins/slack/manifest.json
@@ -8,6 +8,20 @@
   "tier": "community",
   "license": "MIT",
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "SLACK_BOT_TOKEN",
+      "sensitive": true,
+      "description": "Slack bot token (xoxb-…). Referenced as ${SLACK_BOT_TOKEN}.",
+      "prompt": "Slack bot token"
+    },
+    {
+      "name": "SLACK_APP_TOKEN",
+      "sensitive": true,
+      "description": "Slack app-level token (xapp-…) for Socket Mode. Referenced as ${SLACK_APP_TOKEN}.",
+      "prompt": "Slack app token"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-slack",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-slack",
   "keywords": [

--- a/plugins/twilio/manifest.json
+++ b/plugins/twilio/manifest.json
@@ -8,6 +8,20 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.51.2",
+  "required_secrets": [
+    {
+      "name": "TWILIO_ACCOUNT_SID",
+      "sensitive": false,
+      "description": "Twilio Account SID (identifier). Referenced as ${TWILIO_ACCOUNT_SID}.",
+      "prompt": "Twilio Account SID"
+    },
+    {
+      "name": "TWILIO_AUTH_TOKEN",
+      "sensitive": true,
+      "description": "Twilio auth token (primary auth path; API-key path uses TWILIO_API_KEY + TWILIO_API_SECRET instead). Referenced as ${TWILIO_AUTH_TOKEN}.",
+      "prompt": "Twilio auth token"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-twilio",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-twilio",
   "keywords": [


### PR DESCRIPTION
Part of the **required_secrets advertisement sweep** (design+plan in workspace docs/plans/2026-05-31-plugin-required-secrets-sweep*.md; ADR 0006). Advertises `required_secrets[]` so `wfctl secrets setup --plugin <x>` provisions credentials uniformly.

**Tier 1 (7):** aws, azure, payments, twilio, slack, github, discord. Names verified per design §4 (plugin source / SDK standard / our consumer configs). `sensitive:false` = identifiers (client_id, tenant_id, account_sid, subscription_id).

**No release / no version bump** — the registry manifest is the install-populating source (`writeInstalledManifest` copies `RequiredSecrets`; `registry-sync` preserves it; ADR 0006). `version`/`downloads` untouched.

**Verify:** `scripts/validate-manifests.sh` → "All plugin manifests are valid." Runtime proof: `secrets setup --plugin azure` recognizes the secrets (advances past the empty-check) — no longer a no-op.

Copilot not requested (service down per operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)