### PR TITLE
chore(registry): required_secrets for tier-2 plugins (okta/turnio/vectorstore/datadog)

### DIFF
--- a/plugins/datadog/manifest.json
+++ b/plugins/datadog/manifest.json
@@ -8,6 +8,20 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.3.30",
+  "required_secrets": [
+    {
+      "name": "DATADOG_API_KEY",
+      "sensitive": true,
+      "description": "Datadog API key. Referenced as ${DATADOG_API_KEY} in apiKey.",
+      "prompt": "Datadog API key"
+    },
+    {
+      "name": "DATADOG_APP_KEY",
+      "sensitive": true,
+      "description": "Datadog application key (required alongside the API key). Referenced as ${DATADOG_APP_KEY} in appKey.",
+      "prompt": "Datadog application key"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-datadog",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-datadog",
   "keywords": [

--- a/plugins/okta/manifest.json
+++ b/plugins/okta/manifest.json
@@ -8,6 +8,20 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "OKTA_ORG_URL",
+      "sensitive": false,
+      "description": "Okta org URL (e.g. https://example.okta.com). Referenced as ${OKTA_ORG_URL}.",
+      "prompt": "Okta org URL"
+    },
+    {
+      "name": "OKTA_API_TOKEN",
+      "sensitive": true,
+      "description": "Okta API token (primary auth path; OAuth path uses clientId + privateKey instead). Referenced as ${OKTA_API_TOKEN}.",
+      "prompt": "Okta API token"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-okta",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-okta",
   "keywords": [

--- a/plugins/turnio/manifest.json
+++ b/plugins/turnio/manifest.json
@@ -8,6 +8,14 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "TURNIO_API_TOKEN",
+      "sensitive": true,
+      "description": "Turn.io API token. Referenced as ${TURNIO_API_TOKEN} in apiToken.",
+      "prompt": "Turn.io API token"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-turnio",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-turnio",
   "keywords": [

--- a/plugins/vectorstore/manifest.json
+++ b/plugins/vectorstore/manifest.json
@@ -8,6 +8,14 @@
   "tier": "core",
   "private": false,
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "PINECONE_API_KEY",
+      "sensitive": true,
+      "description": "Pinecone API key (provider: pinecone). Other vector providers (e.g. Milvus) use their own auth. Referenced as ${PINECONE_API_KEY}.",
+      "prompt": "Pinecone API key"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-vectorstore",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-vectorstore",
   "keywords": [


### PR DESCRIPTION
Part of the required_secrets sweep (design+plan workspace docs/plans/2026-05-31-plugin-required-secrets-sweep*.md; ADR 0006). **Tier 2 registered subset** — entra/scalekit are unregistered (no manifest), handled via plugin.json-only + a register follow-up (plan Backport). Names per design §4. No release (registry is install-populating source). validate-manifests: All plugin manifests are valid. Copilot not requested (down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)