### PR TITLE
chore(registry): required_secrets for tier-3 plugins (gcp/salesforce/monday/launchdarkly)

### DIFF
--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -8,6 +8,14 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.57.0",
+  "required_secrets": [
+    {
+      "name": "GCP_SERVICE_ACCOUNT_JSON",
+      "sensitive": true,
+      "description": "GCP service-account JSON key (inline blob). For the credentials.service_account_json path; ADC / Workload Identity deployments may skip. Referenced as ${GCP_SERVICE_ACCOUNT_JSON}.",
+      "prompt": "GCP service-account JSON"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
   "keywords": [

--- a/plugins/launchdarkly/manifest.json
+++ b/plugins/launchdarkly/manifest.json
@@ -8,6 +8,14 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "LAUNCHDARKLY_API_KEY",
+      "sensitive": true,
+      "description": "LaunchDarkly REST API (management) key. Referenced as ${LAUNCHDARKLY_API_KEY} in apiKey.",
+      "prompt": "LaunchDarkly API key"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-launchdarkly",
   "keywords": [

--- a/plugins/monday/manifest.json
+++ b/plugins/monday/manifest.json
@@ -8,6 +8,14 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "MONDAY_API_TOKEN",
+      "sensitive": true,
+      "description": "Monday.com API token. Referenced as ${MONDAY_API_TOKEN} in apiToken.",
+      "prompt": "Monday.com API token"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-monday",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-monday",
   "keywords": [

--- a/plugins/salesforce/manifest.json
+++ b/plugins/salesforce/manifest.json
@@ -8,6 +8,20 @@
   "tier": "community",
   "private": false,
   "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "SALESFORCE_CLIENT_ID",
+      "sensitive": false,
+      "description": "Salesforce connected-app consumer key (OAuth path; alternate path uses accessToken + instanceUrl). Referenced as ${SALESFORCE_CLIENT_ID}.",
+      "prompt": "Salesforce client ID"
+    },
+    {
+      "name": "SALESFORCE_CLIENT_SECRET",
+      "sensitive": true,
+      "description": "Salesforce connected-app consumer secret. Referenced as ${SALESFORCE_CLIENT_SECRET}.",
+      "prompt": "Salesforce client secret"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-salesforce",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-salesforce",
   "keywords": [


### PR DESCRIPTION
Part of the required_secrets sweep (ADR 0006). **Tier 3 registered subset** — auth0 unregistered (plugin.json-only + register follow-up, plan Backport). MED-confidence convention-set names per design §4. No release. validate-manifests passes. Copilot not requested (down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)