### PR TITLE
feat(registry): register entra, scalekit, auth0 (v0.1.0) with required_secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These plugins are distributed outside the engine repository and are maintained a
 |--------|-------------|------|
 | [analytics](./plugins/analytics/manifest.json) | Analytics and tag-manager injection for rendered HTML assets | community |
 | [audit-chain](./plugins/audit-chain/manifest.json) | Tamper-evident hash-chained audit logging with periodic Merkle root anchoring (OpenTimestamps/Bitcoin, git, Sigstore) | community |
+| [auth0](./plugins/auth0/manifest.json) | Auth0 identity and access management provider plugin | community |
 | [authz-ui](./plugins/authz-ui/manifest.json) | Casbin authorization policy management UI (React SPA) | premium |
 | [aws](./plugins/aws/manifest.json) | AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, and ACM resources | community |
 | [azure](./plugins/azure/manifest.json) | Microsoft Azure infrastructure provider: ACI, AKS, SQL, Redis, VNet, LB, DNS, ACR, APIM, NSG, MSI, Blob Storage, App Service Certificates | community |
@@ -160,6 +161,7 @@ These plugins are distributed outside the engine repository and are maintained a
 | [datadog](./plugins/datadog/manifest.json) | Datadog monitoring and observability — metrics, events, monitors, dashboards, logs, synthetics, SLOs, incidents, and more | community |
 | [digitalocean](./plugins/digitalocean/manifest.json) | DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage Volumes, IAM, and API gateway | community |
 | [discord](./plugins/discord/manifest.json) | Discord messaging, bot automation, and voice channel support. Provides a provider module, pipeline steps for sending/editing/deleting messages and managing voice, and a WebSocket Gateway event trigger. | community |
+| [entra](./plugins/entra/manifest.json) | Microsoft Entra ID management provider plugin | community |
 | [eventbus](./plugins/eventbus/manifest.json) | Provisions durable event-bus clusters (NATS / Kafka / Kinesis) as IaC and exposes typed pipeline steps for publish / consume operations. | community |
 | [gcp](./plugins/gcp/manifest.json) | GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager | community |
 | [hover](./plugins/hover/manifest.json) | Hover DNS provider for workflow IaC (infra.dns). No official API; mimics the browser-side username+password+TOTP login flow used by pjslauta/hover-dyn-dns. | community |
@@ -172,6 +174,7 @@ These plugins are distributed outside the engine repository and are maintained a
 | [ratchet](./plugins/ratchet/manifest.json) | Autonomous AI agent orchestration platform — custom EnginePlugin for building AI-powered workflow applications with agent coordination, task management, and intelligent pipeline execution | community |
 | [rooms](./plugins/rooms/manifest.json) | Room management plugin for workflow engine — join, leave, broadcast, members | community |
 | [salesforce](./plugins/salesforce/manifest.json) | Salesforce CRM — records, SOQL queries, bulk operations, approvals, flows, reports, dashboards, metadata, and more | community |
+| [scalekit](./plugins/scalekit/manifest.json) | Scalekit enterprise SSO and Directory Sync provider plugin | community |
 | [security-scanner](./plugins/security-scanner/manifest.json) | Security scanner plugin for workflow engine — vulnerability scanning, secret detection, and compliance checks | community |
 | [security](./plugins/security/manifest.json) | Unified security plugin: WAF (Coraza/AWS/GCloud/Cloudflare), MFA/encryption (TOTP, AES-256-GCM, AWS KMS, GCP KMS, Vault Transit), authorization (Casbin RBAC, Permit.io), data protection (PII detection/masking), sandbox (WASM/wazero, Docker), and supply-chain security (signatures, vuln scanning, SBOM) | premium |
 | [slack](./plugins/slack/manifest.json) | Slack messaging and workspace automation. Provides a provider module backed by the Slack Web API and Socket Mode, pipeline steps for messages/blocks/reactions/files, and a Socket Mode event trigger. | community |

--- a/plugins/auth0/manifest.json
+++ b/plugins/auth0/manifest.json
@@ -1,0 +1,96 @@
+{
+  "name": "workflow-plugin-auth0",
+  "version": "0.1.0",
+  "description": "Auth0 identity and access management provider plugin",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "minEngineVersion": "0.64.0",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-auth0",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-auth0",
+  "keywords": [
+    "auth0",
+    "identity",
+    "iam",
+    "sso",
+    "oidc",
+    "rbac"
+  ],
+  "capabilities": {
+    "configProvider": false,
+    "moduleTypes": [
+      "auth0.provider"
+    ],
+    "stepTypes": [
+      "step.auth0_auth_provider_describe",
+      "step.auth0_user_create",
+      "step.auth0_user_get",
+      "step.auth0_user_list",
+      "step.auth0_user_update",
+      "step.auth0_user_delete",
+      "step.auth0_role_create",
+      "step.auth0_role_list",
+      "step.auth0_role_assign_users",
+      "step.auth0_client_create",
+      "step.auth0_client_get",
+      "step.auth0_client_list",
+      "step.auth0_client_update",
+      "step.auth0_client_delete",
+      "step.auth0_connection_list",
+      "step.auth0_organization_create",
+      "step.auth0_organization_get",
+      "step.auth0_organization_list"
+    ],
+    "triggerTypes": []
+  },
+  "required_secrets": [
+    {
+      "name": "AUTH0_DOMAIN",
+      "sensitive": false,
+      "description": "Auth0 tenant domain (e.g. example.us.auth0.com). Referenced as ${AUTH0_DOMAIN}.",
+      "prompt": "Auth0 domain"
+    },
+    {
+      "name": "AUTH0_CLIENT_ID",
+      "sensitive": false,
+      "description": "Auth0 M2M application client ID. Referenced as ${AUTH0_CLIENT_ID}.",
+      "prompt": "Auth0 client ID"
+    },
+    {
+      "name": "AUTH0_CLIENT_SECRET",
+      "sensitive": true,
+      "description": "Auth0 M2M application client secret (client-credentials path; static-token path uses a management token instead). Referenced as ${AUTH0_CLIENT_SECRET}.",
+      "prompt": "Auth0 client secret"
+    }
+  ],
+  "downloads": [
+    {
+      "os": "darwin",
+      "arch": "amd64",
+      "sha256": "2bfd9e8083b96747e1c14c2161b9a5b2ed3b0baf97afacfcd5513d0350efd7c8",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth0/releases/download/v0.1.0/workflow-plugin-auth0-darwin-amd64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "sha256": "2552a900f699d47515f539596acee89b821a8ddc1dfacf9fdb2e996cac91a0f4",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth0/releases/download/v0.1.0/workflow-plugin-auth0-darwin-arm64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "sha256": "fc9649d7af13963dd08ca06fd099d1b0925d172c234b537fc46648af4823e8b2",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth0/releases/download/v0.1.0/workflow-plugin-auth0-linux-amd64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "arm64",
+      "sha256": "69762b2f256b54105d745c949f149497b910a35ecbeb433337fe1bdef1f58c0c",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-auth0/releases/download/v0.1.0/workflow-plugin-auth0-linux-arm64.tar.gz"
+    }
+  ],
+  "status": "experimental",
+  "category": "integrations"
+}

--- a/plugins/entra/manifest.json
+++ b/plugins/entra/manifest.json
@@ -1,0 +1,96 @@
+{
+  "name": "workflow-plugin-entra",
+  "version": "0.1.0",
+  "description": "Microsoft Entra ID management provider plugin",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "minEngineVersion": "0.64.0",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-entra",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-entra",
+  "keywords": [
+    "entra",
+    "microsoft-graph",
+    "identity",
+    "iam",
+    "sso",
+    "oidc"
+  ],
+  "capabilities": {
+    "configProvider": false,
+    "moduleTypes": [
+      "entra.provider"
+    ],
+    "stepTypes": [
+      "step.entra_auth_provider_describe",
+      "step.entra_user_create",
+      "step.entra_user_get",
+      "step.entra_user_list",
+      "step.entra_user_update",
+      "step.entra_user_delete",
+      "step.entra_group_create",
+      "step.entra_group_get",
+      "step.entra_group_list",
+      "step.entra_group_add_member",
+      "step.entra_group_remove_member",
+      "step.entra_application_create",
+      "step.entra_application_get",
+      "step.entra_application_list",
+      "step.entra_application_update",
+      "step.entra_application_delete",
+      "step.entra_directory_role_list",
+      "step.entra_service_principal_list"
+    ],
+    "triggerTypes": []
+  },
+  "required_secrets": [
+    {
+      "name": "ENTRA_TENANT_ID",
+      "sensitive": false,
+      "description": "Microsoft Entra ID tenant ID. Referenced as ${ENTRA_TENANT_ID} in the provider tenant_id config.",
+      "prompt": "Entra tenant ID"
+    },
+    {
+      "name": "ENTRA_CLIENT_ID",
+      "sensitive": false,
+      "description": "Entra app client ID. Referenced as ${ENTRA_CLIENT_ID} in client_id.",
+      "prompt": "Entra client ID"
+    },
+    {
+      "name": "ENTRA_CLIENT_SECRET",
+      "sensitive": true,
+      "description": "Entra app client secret. Referenced as ${ENTRA_CLIENT_SECRET} in client_secret.",
+      "prompt": "Entra client secret"
+    }
+  ],
+  "downloads": [
+    {
+      "os": "darwin",
+      "arch": "amd64",
+      "sha256": "7f2cb1748e654c615ec1baf5e05ab83e55e9404417b65c1bf41b9fa29e90db29",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-entra/releases/download/v0.1.0/workflow-plugin-entra-darwin-amd64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "sha256": "390ffd0ee57f96ddd97db93f1461d133b69838dfeb73f835b74149fd6ab14f68",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-entra/releases/download/v0.1.0/workflow-plugin-entra-darwin-arm64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "sha256": "95c780770247438c848b40a2352ecabc5b2271f616331ddc44a2427bb8f42a74",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-entra/releases/download/v0.1.0/workflow-plugin-entra-linux-amd64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "arm64",
+      "sha256": "44af7c207487888ea721584d27630a306bc9696532beb7dc3983869e80e2c67e",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-entra/releases/download/v0.1.0/workflow-plugin-entra-linux-arm64.tar.gz"
+    }
+  ],
+  "status": "experimental",
+  "category": "integrations"
+}

--- a/plugins/scalekit/manifest.json
+++ b/plugins/scalekit/manifest.json
@@ -1,0 +1,93 @@
+{
+  "name": "workflow-plugin-scalekit",
+  "version": "0.1.0",
+  "description": "Scalekit enterprise SSO and Directory Sync provider plugin",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "minEngineVersion": "0.64.0",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-scalekit",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-scalekit",
+  "keywords": [
+    "scalekit",
+    "sso",
+    "saml",
+    "oidc",
+    "scim",
+    "directory-sync"
+  ],
+  "capabilities": {
+    "configProvider": false,
+    "moduleTypes": [
+      "scalekit.provider"
+    ],
+    "stepTypes": [
+      "step.scalekit_auth_provider_describe",
+      "step.scalekit_connection_create",
+      "step.scalekit_connection_get",
+      "step.scalekit_connection_list",
+      "step.scalekit_connection_enable",
+      "step.scalekit_connection_disable",
+      "step.scalekit_connection_delete",
+      "step.scalekit_directory_create",
+      "step.scalekit_directory_get",
+      "step.scalekit_directory_list",
+      "step.scalekit_directory_enable",
+      "step.scalekit_directory_disable",
+      "step.scalekit_directory_delete",
+      "step.scalekit_directory_user_list",
+      "step.scalekit_directory_group_list"
+    ],
+    "triggerTypes": []
+  },
+  "required_secrets": [
+    {
+      "name": "SCALEKIT_ENVIRONMENT_URL",
+      "sensitive": false,
+      "description": "Scalekit environment URL. Referenced as ${SCALEKIT_ENVIRONMENT_URL}.",
+      "prompt": "Scalekit environment URL"
+    },
+    {
+      "name": "SCALEKIT_CLIENT_ID",
+      "sensitive": false,
+      "description": "Scalekit client ID. Referenced as ${SCALEKIT_CLIENT_ID}.",
+      "prompt": "Scalekit client ID"
+    },
+    {
+      "name": "SCALEKIT_CLIENT_SECRET",
+      "sensitive": true,
+      "description": "Scalekit client secret. Referenced as ${SCALEKIT_CLIENT_SECRET}.",
+      "prompt": "Scalekit client secret"
+    }
+  ],
+  "downloads": [
+    {
+      "os": "darwin",
+      "arch": "amd64",
+      "sha256": "9da66a090180df18baa0027fe5f87399fb2fe98bfe80416c3b05a960408babb9",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-scalekit/releases/download/v0.1.0/workflow-plugin-scalekit-darwin-amd64.tar.gz"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "sha256": "1199eeb6e28310880ade6779c9ecf9b1f8a12089b6bf67f04f206a9fb9ac2467",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-scalekit/releases/download/v0.1.0/workflow-plugin-scalekit-darwin-arm64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "sha256": "49f1cb09e4602a62c29a677048bb75ddbf646a54c584cfb5f5735630de3cfd4f",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-scalekit/releases/download/v0.1.0/workflow-plugin-scalekit-linux-amd64.tar.gz"
+    },
+    {
+      "os": "linux",
+      "arch": "arm64",
+      "sha256": "7fc966b361d9c79c73abc750ac0c8bb42697b8c4eeac76131ac5c4cba56b487c",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-scalekit/releases/download/v0.1.0/workflow-plugin-scalekit-linux-arm64.tar.gz"
+    }
+  ],
+  "status": "experimental",
+  "category": "integrations"
+}


### PR DESCRIPTION
## Summary

- Registers 3 new community IAM/SSO plugins: **entra**, **scalekit**, **auth0** at v0.1.0
- Each manifest includes `required_secrets` verbatim from the plugin's `plugin.json` (already merged in a prior sweep), real sha256 from v0.1.0 `checksums.txt`, capabilities, `minEngineVersion: 0.64.0`, and `status: experimental` / `category: integrations`
- README regenerated (3 new rows, alphabetically placed)

## Registration mechanism

**Hand-authored** — `sync-registry-manifests.yml` line 173 explicitly skips dispatch when `plugins/<name>/manifest.json` does not exist (`skip=1`). The auto-notify path only UPDATES existing manifests, it cannot CREATE new ones. Auto-notify was the correct mechanism for subsequent version bumps; initial registration always requires a hand-authored manifest PR.

## Gap flagged

All 3 plugin release workflows (`release.yml`) are missing the `repository_dispatch` notify step that okta and other mature plugins have. Future version bumps for entra/scalekit/auth0 will NOT auto-sync to the registry until that step is added to each plugin's `release.yml`.

## Validate output

```
All plugin manifests are valid.
```

All 3 new manifests print `valid`; overall result is clean.

## Runtime proof

`wfctl secrets setup --plugin <name>` with a plugin.json derived from each registry manifest produces `error: secrets: env var "UNSET" is empty or unset` — meaning required_secrets was recognized and wfctl proceeded to the GitHub secrets writer (past the `declares no required_secrets[]; nothing to do` early-exit). Contrast confirmed with a zero-required_secrets plugin that does print the early-exit message.