### PR TITLE
feat: register workflow-plugin-edge-compute (public)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ These plugins are distributed outside the engine repository and are maintained a
 | [datadog](./plugins/datadog/manifest.json) | Datadog monitoring and observability — metrics, events, monitors, dashboards, logs, synthetics, SLOs, incidents, and more | community |
 | [digitalocean](./plugins/digitalocean/manifest.json) | DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage Volumes, IAM, and API gateway | community |
 | [discord](./plugins/discord/manifest.json) | Discord messaging, bot automation, and voice channel support. Provides a provider module, pipeline steps for sending/editing/deleting messages and managing voice, and a WebSocket Gateway event trigger. | community |
+| [edge-compute](./plugins/edge-compute/manifest.json) | Edge WASM provider contracts for workflow-compute | community |
 | [entra](./plugins/entra/manifest.json) | Microsoft Entra ID management provider plugin | community |
 | [eventbus](./plugins/eventbus/manifest.json) | Provisions durable event-bus clusters (NATS / Kafka / Kinesis) as IaC and exposes typed pipeline steps for publish / consume operations. | community |
 | [gcp](./plugins/gcp/manifest.json) | GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager | community |

--- a/plugins/edge-compute/manifest.json
+++ b/plugins/edge-compute/manifest.json
@@ -1,0 +1,28 @@
+{
+  "name": "workflow-plugin-edge-compute",
+  "version": "0.1.0",
+  "description": "Edge WASM provider contracts for workflow-compute",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "minEngineVersion": "0.57.4",
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-edge-compute",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-edge-compute",
+  "keywords": [
+    "edge",
+    "wasm",
+    "workflow-compute",
+    "cdn",
+    "lambda"
+  ],
+  "capabilities": {
+    "configProvider": false,
+    "moduleTypes": [],
+    "stepTypes": [],
+    "triggerTypes": []
+  },
+  "status": "experimental",
+  "category": "infrastructure"
+}


### PR DESCRIPTION
Registers the public **workflow-plugin-edge-compute** plugin (one of 4 unregistered plugins found in the okta-fleet audit; the other 3 are private and skipped).

## What
- Adds `plugins/edge-compute/manifest.json` (hand-authored from the repo's `plugin.json`).
- Regenerates the README plugin index.

## Why downloads are omitted
edge-compute has **no release yet** (no tags/assets). The registry resolver only needs `plugins/<name>/manifest.json` to exist for the plugin's `plugin-release` dispatch to resolve. Downloads (version + per-arch sha256) are populated automatically by the `sync-registry-manifests` workflow's `sync-versions.sh` on the plugin's first `v*` release. This matches existing downloads-absent registered manifests (actors, agent, ai, …). `validate-manifests.sh` passes.

It is a contracts-only plugin (empty module/step/trigger capabilities; defines edge WASM provider contracts), so `status: experimental`.

A companion PR fixes its release.yml registry-notify to the canonical form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)