### PR TITLE
chore: sync authz-ui registry manifest

### DIFF
--- a/plugins/authz-ui/manifest.json
+++ b/plugins/authz-ui/manifest.json
@@ -1,26 +1,9 @@
 {
-  "name": "authz-ui",
-  "version": "1.0.3",
+  "assets": {
+    "config": false,
+    "ui": true
+  },
   "author": "GoCodeAlone",
-  "description": "Casbin authorization policy management UI (React SPA)",
-  "source": "github.com/GoCodeAlone/workflow-plugin-authz-ui",
-  "type": "external",
-  "tier": "premium",
-  "license": "Proprietary",
-  "private": true,
-  "minEngineVersion": "0.53.0",
-  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
-  "repository": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
-  "keywords": [
-    "authz",
-    "casbin",
-    "ui",
-    "policy",
-    "rbac",
-    "authorization",
-    "react",
-    "spa"
-  ],
   "capabilities": {
     "configProvider": true,
     "moduleTypes": [
@@ -33,35 +16,48 @@
     ],
     "triggerTypes": []
   },
-  "assets": {
-    "ui": true,
-    "config": false
-  },
+  "category": "core",
+  "description": "Casbin authorization policy management UI (React SPA)",
   "downloads": [
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "071f731d1f4963ede34aea8e728912543817831748bc97fc6a85544dcedea75e",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "b6046fef768382599e3a3034512e45c7b5b6ad213de59f736076674ad80463a4",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "cb1b4b2b99bc073e0403bec21ecbc4eed6c170bb86958614dc81076ff445814d",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "62efed6c10169d38ef41c11e38718bf0c17bba45d768ff29ab9d8683807d2678",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.3/workflow-plugin-authz-ui-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-linux-arm64.tar.gz"
     }
   ],
-  "category": "core"
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
+  "keywords": [
+    "authz",
+    "casbin",
+    "ui",
+    "policy",
+    "rbac",
+    "authorization",
+    "react",
+    "spa"
+  ],
+  "license": "Proprietary",
+  "minEngineVersion": "0.53.0",
+  "name": "authz-ui",
+  "private": true,
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui",
+  "source": "github.com/GoCodeAlone/workflow-plugin-authz-ui",
+  "tier": "premium",
+  "type": "external",
+  "version": "1.0.7"
 }

--- a/plugins/authz-ui/manifest.json
+++ b/plugins/authz-ui/manifest.json
@@ -22,21 +22,25 @@
     {
       "arch": "amd64",
       "os": "darwin",
+      "sha256": "534d4d3a7b37d3b33244499d38d6b58e0ebb0e7b9893d36a9ffae7cddf05f03e",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
+      "sha256": "df3a16e5a151eae5da09e0f476ddee3805293d90e6ac1b0b085cab673bfa40df",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
+      "sha256": "a066cb63e291522d837962563c16d11397ee61da5781a16393ad7e544220982e",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
+      "sha256": "7da43deac39dc4fd66731bae813138b5cfb7d449c2544ae97343476cceb6e853",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-authz-ui/releases/download/v1.0.7/workflow-plugin-authz-ui-linux-arm64.tar.gz"
     }
   ],


### PR DESCRIPTION
## Summary
- clean replacement for stale generated PR #190
- updates authz-ui from 1.0.3 to 1.0.7
- verifies fixed wfctl registry-sync no longer mutates builtin manifests

## Verification
- /tmp/wfctl-762-builtin plugin registry-sync --fix --registry-dir .
- /tmp/wfctl-762-builtin plugin registry-sync core --fix --registry-dir . --workflow-repo /Users/jon/workspace/workflow/.worktrees/issue-762-registry-builtin-skip
- /tmp/wfctl-762-builtin plugin registry-sync readme --registry-dir .
- git diff --check
- bash scripts/validate-manifests.sh
- bash scripts/validate-templates.sh
- bash scripts/categorize-manifests.sh --check

## Notes
- Closed #190 because it preserved stale builtin downloads from the pre-v0.69.7 generator bug.