### PR TITLE
chore: sync supply-chain to v0.4.7

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -103,7 +103,7 @@ jobs:
         if: steps.filter.outputs.skip != '1'
         id: sync
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASES_TOKEN || secrets.GITHUB_TOKEN }}
           PLUGIN:   ${{ steps.filter.outputs.plugin }}
         run: |
           set -euo pipefail
@@ -134,6 +134,7 @@ jobs:
         if: steps.sync.outputs.changed != '0' && steps.filter.outputs.skip != '1'
         env:
           GH_TOKEN:        ${{ secrets.GITHUB_TOKEN }}
+          WFCTL_GH_TOKEN:  ${{ secrets.RELEASES_TOKEN || secrets.GITHUB_TOKEN }}
           PLUGIN:          ${{ steps.filter.outputs.plugin }}
           EVENT_NAME:      ${{ github.event_name }}
           DISPATCH_ACTION: ${{ github.event.action }}
@@ -220,9 +221,9 @@ jobs:
               git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}"
               git checkout -B "${BRANCH}" "refs/remotes/origin/${BRANCH}"
               if [[ -n "${PLUGIN}" ]]; then
-                wfctl plugin registry-sync --fix --plugin "${PLUGIN}" --registry-dir .
+                GH_TOKEN="${WFCTL_GH_TOKEN}" wfctl plugin registry-sync --fix --plugin "${PLUGIN}" --registry-dir .
               else
-                wfctl plugin registry-sync --fix --registry-dir .
+                GH_TOKEN="${WFCTL_GH_TOKEN}" wfctl plugin registry-sync --fix --registry-dir .
                 wfctl plugin registry-sync core --fix --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"
               fi
               wfctl plugin registry-sync readme --registry-dir .

--- a/plugins/workflow-plugin-supply-chain/manifest.json
+++ b/plugins/workflow-plugin-supply-chain/manifest.json
@@ -1,15 +1,129 @@
 {
-  "name": "workflow-plugin-supply-chain",
-  "version": "0.3.0",
-  "description": "Supply chain security: SBOM generation, keyless signing, SLSA provenance, vulnerability scanning, and wfctl CLI extensions",
+  "assets": {
+    "config": true,
+    "ui": false
+  },
   "author": "GoCodeAlone",
-  "license": "MIT",
-  "type": "external",
-  "tier": "core",
-  "private": false,
-  "minEngineVersion": "0.18.0",
+  "capabilities": {
+    "buildHooks": [
+      {
+        "description": "Generate CycloneDX SBOM via syft and attach to image as OCI artifact",
+        "event": "post_container_build",
+        "on_hook_failure": "fail",
+        "priority": 500
+      },
+      {
+        "description": "Keyless-sign the built image digest via cosign + GitHub OIDC",
+        "event": "post_container_build",
+        "on_hook_failure": "fail",
+        "priority": 600
+      },
+      {
+        "description": "Sign release assets (tarballs, binaries, SBOMs) via cosign sign-blob",
+        "event": "post_artifacts_publish",
+        "on_hook_failure": "fail",
+        "priority": 500
+      },
+      {
+        "description": "Verify plugin tarball signature and SBOM before extraction",
+        "event": "install_verify",
+        "on_hook_failure": "fail",
+        "priority": 500
+      }
+    ],
+    "cliCommands": [
+      {
+        "description": "Supply-chain verification and SBOM commands",
+        "flags_passthrough": true,
+        "name": "supply-chain",
+        "subcommands": [
+          {
+            "description": "Scan image with syft (OSV planned)",
+            "name": "scan"
+          },
+          {
+            "description": "Verify cosign signature and SBOM",
+            "name": "verify"
+          },
+          {
+            "description": "Generate CycloneDX SBOM",
+            "name": "sbom"
+          },
+          {
+            "description": "Full supply-chain report",
+            "name": "report"
+          }
+        ]
+      },
+      {
+        "description": "Scaffold supply-chain config into app.yaml and CI",
+        "flags_passthrough": true,
+        "name": "scaffold",
+        "subcommands": [
+          {
+            "description": "Add SBOM config to app.yaml + CI",
+            "name": "sbom"
+          },
+          {
+            "description": "Add signing config to app.yaml + CI",
+            "name": "sign"
+          }
+        ]
+      },
+      {
+        "description": "CI preflight and doctor commands",
+        "flags_passthrough": true,
+        "name": "ci",
+        "subcommands": [
+          {
+            "description": "Run supply-chain preflight checks",
+            "name": "doctor"
+          }
+        ]
+      }
+    ],
+    "configProvider": false,
+    "moduleTypes": [
+      "security.plugin-verifier",
+      "security.scanner.trivy",
+      "security.scanner.grype",
+      "security.scanner.snyk",
+      "security.scanner.ecr",
+      "security.scanner.gcp-artifact"
+    ],
+    "stepTypes": [
+      "step.verify_signature",
+      "step.vuln_scan",
+      "step.sbom_generate",
+      "step.sbom_check"
+    ],
+    "triggerTypes": []
+  },
+  "category": "security",
+  "description": "Supply chain security: SBOM generation, keyless signing, SLSA provenance, vulnerability scanning, and wfctl CLI extensions",
+  "downloads": [
+    {
+      "arch": "amd64",
+      "os": "darwin",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.4.7/workflow-plugin-supply-chain-darwin-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.4.7/workflow-plugin-supply-chain-darwin-arm64.tar.gz"
+    },
+    {
+      "arch": "amd64",
+      "os": "linux",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.4.7/workflow-plugin-supply-chain-linux-amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "linux",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.4.7/workflow-plugin-supply-chain-linux-arm64.tar.gz"
+    }
+  ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain",
-  "repository": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain",
   "keywords": [
     "supply-chain",
     "security",
@@ -22,125 +136,12 @@
     "syft",
     "sigstore"
   ],
-  "capabilities": {
-    "moduleTypes": [
-      "security.plugin-verifier",
-      "security.scanner",
-      "security.scanner.grype",
-      "security.scanner.snyk",
-      "security.scanner.ecr",
-      "security.scanner.gcp-artifact"
-    ],
-    "stepTypes": [
-      "step.verify_signature",
-      "step.vuln_scan",
-      "step.sbom_generate",
-      "step.sbom_check"
-    ],
-    "triggerTypes": [],
-    "buildHooks": [
-      {
-        "event": "post_container_build",
-        "priority": 500,
-        "on_hook_failure": "fail",
-        "description": "Generate CycloneDX SBOM via syft and attach to image as OCI artifact"
-      },
-      {
-        "event": "post_container_build",
-        "priority": 600,
-        "on_hook_failure": "fail",
-        "description": "Keyless-sign the built image digest via cosign + GitHub OIDC"
-      },
-      {
-        "event": "post_artifacts_publish",
-        "priority": 500,
-        "on_hook_failure": "fail",
-        "description": "Sign release assets (tarballs, binaries, SBOMs) via cosign sign-blob"
-      },
-      {
-        "event": "install_verify",
-        "priority": 500,
-        "on_hook_failure": "fail",
-        "description": "Verify plugin tarball signature and SBOM before extraction"
-      }
-    ],
-    "cliCommands": [
-      {
-        "name": "supply-chain",
-        "description": "Supply-chain verification and SBOM commands",
-        "flags_passthrough": true,
-        "subcommands": [
-          {
-            "name": "scan",
-            "description": "Scan image with syft (OSV planned)"
-          },
-          {
-            "name": "verify",
-            "description": "Verify cosign signature and SBOM"
-          },
-          {
-            "name": "sbom",
-            "description": "Generate CycloneDX SBOM"
-          },
-          {
-            "name": "report",
-            "description": "Full supply-chain report"
-          }
-        ]
-      },
-      {
-        "name": "scaffold",
-        "description": "Scaffold supply-chain config into app.yaml and CI",
-        "flags_passthrough": true,
-        "subcommands": [
-          {
-            "name": "sbom",
-            "description": "Add SBOM config to app.yaml + CI"
-          },
-          {
-            "name": "sign",
-            "description": "Add signing config to app.yaml + CI"
-          }
-        ]
-      },
-      {
-        "name": "ci",
-        "description": "CI preflight and doctor commands",
-        "flags_passthrough": true,
-        "subcommands": [
-          {
-            "name": "doctor",
-            "description": "Run supply-chain preflight checks"
-          }
-        ]
-      }
-    ]
-  },
-  "assets": {
-    "ui": false,
-    "config": true
-  },
-  "downloads": [
-    {
-      "os": "linux",
-      "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.3.0/workflow-plugin-supply-chain-linux-amd64.tar.gz"
-    },
-    {
-      "os": "linux",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.3.0/workflow-plugin-supply-chain-linux-arm64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.3.0/workflow-plugin-supply-chain-darwin-amd64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain/releases/download/v0.3.0/workflow-plugin-supply-chain-darwin-arm64.tar.gz"
-    }
-  ],
-  "category": "security"
+  "license": "MIT",
+  "minEngineVersion": "0.53.0",
+  "name": "workflow-plugin-supply-chain",
+  "private": false,
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-supply-chain",
+  "tier": "core",
+  "type": "external",
+  "version": "0.4.7"
 }

--- a/tests/test-sync-workflow-token.sh
+++ b/tests/test-sync-workflow-token.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/sync-registry-manifests.yml"
+
+if ! grep -Fq 'GH_TOKEN: ${{ secrets.RELEASES_TOKEN || secrets.GITHUB_TOKEN }}' "$workflow"; then
+  echo "sync-registry-manifests must expose RELEASES_TOKEN to wfctl for private plugin releases" >&2
+  exit 1
+fi


### PR DESCRIPTION
Updates workflow-plugin-supply-chain in the registry to the published v0.4.7 release and fixes the registry sync workflow so wfctl can read private plugin releases with RELEASES_TOKEN when available.

Root cause: workflow-plugin-supply-chain is private, so the registry repo GITHUB_TOKEN could not see its releases during repository_dispatch sync. Public plugins like teams/sso were unaffected.

Verification:
- GH_TOKEN="$(gh auth token)" /tmp/wfctl-v0695/wfctl-darwin-arm64 plugin registry-sync --fix --plugin workflow-plugin-supply-chain --registry-dir .
- bash tests/test-sync-workflow-token.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync-registry-manifests.yml"); puts "yaml ok"'\n- /tmp/wfctl-v0695/wfctl-darwin-arm64 plugin registry-sync core --registry-dir . --workflow-repo /Users/jon/workspace/workflow/.worktrees/latest-main\n- bash scripts/validate-manifests.sh\n- bash tests/test-build-index.sh\n- bash tests/test-schema-allowlist-coverage.sh