### PR TITLE
fix(infra): drop 'path' from external workflow-plugin-infra manifest

### DIFF
--- a/plugins/workflow-plugin-infra/manifest.json
+++ b/plugins/workflow-plugin-infra/manifest.json
@@ -81,7 +81,6 @@
   "license": "MIT",
   "minEngineVersion": "0.70.0",
   "name": "workflow-plugin-infra",
-  "path": "plugins/workflow-plugin-infra",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-infra",
   "source": "github.com/GoCodeAlone/workflow-plugin-infra",


### PR DESCRIPTION
Follow-up to #203 (Copilot nit): external plugin manifests omit `path` (authz-ui/admin/auth all do) — it documents a path within the *source repo*, and the plugin sits at its repo root, not `plugins/workflow-plugin-infra`. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)