### PR TITLE
fix: harden registry version build

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build version data
         run: bash scripts/build-versions.sh
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/scripts/build-versions.sh
+++ b/scripts/build-versions.sh
@@ -31,6 +31,18 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
+GH_TIMEOUT_SECONDS="${GH_TIMEOUT_SECONDS:-45}"
+release_cache_root="$(mktemp -d "${TMPDIR:-/tmp}/workflow-registry-releases.XXXXXX")"
+trap 'rm -rf "${release_cache_root}"' EXIT
+
+run_gh() {
+  if command -v timeout &>/dev/null; then
+    timeout "${GH_TIMEOUT_SECONDS}s" gh "$@"
+  else
+    gh "$@"
+  fi
+}
+
 echo "Building version data..."
 
 mkdir -p "${OUT_DIR}/plugins"
@@ -54,18 +66,25 @@ while IFS= read -r manifest; do
 
   # Extract owner/repo from URL, normalizing trailing slashes, .git suffix, and extra path segments
   gh_repo="$(echo "${repository}" | sed 's|https://github.com/||; s|http://github.com/||; s|github.com/||; s|\.git$||; s|/$||' | cut -d/ -f1,2)"
+  repo_cache_dir="${release_cache_root}/$(echo "${gh_repo}" | tr '/:' '__')"
+  mkdir -p "${repo_cache_dir}"
 
   echo "  ${plugin_name}: fetching releases for ${gh_repo}..."
 
   # List releases (tagName + publishedAt only; assets not available in list output)
-  if ! releases_list="$(gh release list \
-    --repo "${gh_repo}" \
-    --limit 100 \
-    --json tagName,publishedAt \
-    2>&1)"; then
-    echo "    WARNING: failed to list releases for ${gh_repo}: ${releases_list}" >&2
-    releases_list="[]"
+  releases_cache="${repo_cache_dir}/releases.json"
+  if [[ ! -f "${releases_cache}" ]]; then
+    if ! releases_list="$(run_gh release list \
+      --repo "${gh_repo}" \
+      --limit 100 \
+      --json tagName,publishedAt \
+      2>&1)"; then
+      echo "    WARNING: failed to list releases for ${gh_repo}: ${releases_list}" >&2
+      releases_list="[]"
+    fi
+    printf '%s\n' "${releases_list}" > "${releases_cache}"
   fi
+  releases_list="$(cat "${releases_cache}")"
 
   if [[ "${releases_list}" == "[]" ]] || [[ "$(echo "${releases_list}" | jq 'length')" == "0" ]]; then
     echo "    no releases found"
@@ -82,13 +101,19 @@ while IFS= read -r manifest; do
     ver="$(echo "${tag}" | sed 's/^v//')"
 
     # gh release view returns assets with a `digest` field (sha256:... format)
-    if ! release_detail="$(gh release view "${tag}" \
-      --repo "${gh_repo}" \
-      --json assets \
-      2>&1)"; then
-      echo "    WARNING: failed to fetch assets for ${gh_repo}@${tag}: ${release_detail}" >&2
-      release_detail='{"assets":[]}'
+    tag_cache_key="$(echo "${tag}" | sed 's/[^A-Za-z0-9._-]/_/g')"
+    release_detail_cache="${repo_cache_dir}/${tag_cache_key}.json"
+    if [[ ! -f "${release_detail_cache}" ]]; then
+      if ! release_detail="$(run_gh release view "${tag}" \
+        --repo "${gh_repo}" \
+        --json assets \
+        2>&1)"; then
+        echo "    WARNING: failed to fetch assets for ${gh_repo}@${tag}: ${release_detail}" >&2
+        release_detail='{"assets":[]}'
+      fi
+      printf '%s\n' "${release_detail}" > "${release_detail_cache}"
     fi
+    release_detail="$(cat "${release_detail_cache}")"
 
     version_entry="$(echo "${release_detail}" | jq \
       --arg ver "${ver}" \

--- a/tests/test-build-pages-release-token.sh
+++ b/tests/test-build-pages-release-token.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/build-pages.yml"
+script="scripts/build-versions.sh"
+
+if ! grep -Fq 'GH_TOKEN: ${{ secrets.RELEASES_TOKEN || secrets.GITHUB_TOKEN }}' "$workflow"; then
+  echo "build-pages must expose RELEASES_TOKEN to version metadata generation" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'run_gh release list' "$script" || ! grep -Fq 'run_gh release view' "$script"; then
+  echo "build-versions must wrap gh release calls with a timeout guard" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'release_cache_root=' "$script" || ! grep -Fq 'repo_cache_dir=' "$script"; then
+  echo "build-versions must cache release API responses by repository" >&2
+  exit 1
+fi


### PR DESCRIPTION
Fixes the Pages version-data build path after the supply-chain registry sync exposed two issues:

- Build version data used only the registry GITHUB_TOKEN, which cannot read private plugin releases such as workflow-plugin-supply-chain.
- build-versions.sh repeatedly queried the same release lists/assets for every manifest pointing at the same repo, making Pages builds slow enough to block the deploy queue.

Changes:
- Use RELEASES_TOKEN when available for Build version data.
- Add a timeout wrapper for gh release calls on Linux runners.
- Cache release list and release asset responses per GitHub repo for the duration of the build.

Verification:
- bash tests/test-build-pages-release-token.sh
- bash -n scripts/build-versions.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-pages.yml"); puts "yaml ok"'\n- bash scripts/validate-manifests.sh\n- bash tests/test-build-index.sh\n- bash tests/test-schema-allowlist-coverage.sh\n- GH_TOKEN="$(gh auth token)" GH_TIMEOUT_SECONDS=45 bash scripts/build-versions.sh