### PR TITLE
fix: avoid large registry version build args

### DIFF
--- a/scripts/build-versions.sh
+++ b/scripts/build-versions.sh
@@ -94,7 +94,8 @@ while IFS= read -r manifest; do
   fi
 
   # For each release tag, fetch full asset list (includes digest/sha256)
-  final_versions="[]"
+  final_versions_file="${release_cache_root}/versions-$(echo "${plugin_name}" | sed 's/[^A-Za-z0-9._-]/_/g').json"
+  printf '[]\n' > "${final_versions_file}"
   while IFS= read -r release_entry; do
     tag="$(echo "${release_entry}" | jq -r '.tagName')"
     published_at="$(echo "${release_entry}" | jq -r '.publishedAt')"
@@ -115,7 +116,8 @@ while IFS= read -r manifest; do
     fi
     release_detail="$(cat "${release_detail_cache}")"
 
-    version_entry="$(echo "${release_detail}" | jq \
+    version_entry_file="${release_cache_root}/version-entry-$(echo "${plugin_name}-${tag}" | sed 's/[^A-Za-z0-9._-]/_/g').json"
+    echo "${release_detail}" | jq \
       --arg ver "${ver}" \
       --arg published_at "${published_at}" \
       --arg minEng "${min_engine}" '
@@ -136,23 +138,26 @@ while IFS= read -r manifest; do
           }
         ]
       }
-    ')"
+    ' > "${version_entry_file}"
 
-    final_versions="$(echo "${final_versions}" | jq --argjson v "${version_entry}" '. + [$v]')"
+    next_versions_file="${final_versions_file}.next"
+    jq --slurpfile v "${version_entry_file}" '. + [$v[0]]' \
+      "${final_versions_file}" > "${next_versions_file}"
+    mv "${next_versions_file}" "${final_versions_file}"
   done < <(echo "${releases_list}" | jq -c '.[]')
 
   # Write versions.json (newest-first order preserved from gh release list)
   jq -n \
     --arg name "${plugin_name}" \
-    --argjson versions "${final_versions}" \
-    '{"name": $name, "versions": $versions}' \
+    --slurpfile versions "${final_versions_file}" \
+    '{"name": $name, "versions": $versions[0]}' \
     > "${dest_dir}/versions.json"
 
-  version_count="$(echo "${final_versions}" | jq 'length')"
+  version_count="$(jq 'length' "${final_versions_file}")"
   echo "    wrote ${version_count} version(s)"
 
   # Write latest.json (first/newest version entry)
-  latest="$(echo "${final_versions}" | jq 'first // null')"
+  latest="$(jq 'first // null' "${final_versions_file}")"
   if [[ "${latest}" != "null" ]]; then
     echo "${latest}" > "${dest_dir}/latest.json"
     echo "    latest: $(echo "${latest}" | jq -r '.version')"

--- a/tests/test-build-pages-release-token.sh
+++ b/tests/test-build-pages-release-token.sh
@@ -18,3 +18,8 @@ if ! grep -Fq 'release_cache_root=' "$script" || ! grep -Fq 'repo_cache_dir=' "$
   echo "build-versions must cache release API responses by repository" >&2
   exit 1
 fi
+
+if grep -Fq -- '--argjson versions "${final_versions}"' "$script"; then
+  echo "build-versions must not pass large version arrays as command-line args" >&2
+  exit 1
+fi


### PR DESCRIPTION
Follow-up to #207 after the fixed Pages build exposed an argument-size failure in scripts/build-versions.sh.

Root cause: for repos with many releases/assets, the script accumulated version JSON in shell variables and passed the full array to jq via --argjson. DigitalOcean release metadata was large enough for /usr/bin/jq to fail with `Argument list too long`.

Changes:
- Accumulate version arrays in temp JSON files.
- Use jq --slurpfile for version entries and final versions output.
- Extend the Pages regression test to reject large version arrays being passed as command-line args.

Verification:
- bash tests/test-build-pages-release-token.sh
- bash -n scripts/build-versions.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-pages.yml"); puts "yaml ok"'\n- GH_TOKEN="$(gh auth token)" GH_TIMEOUT_SECONDS=45 bash scripts/build-versions.sh