### PR TITLE
chore: sync IaC runner plugin manifests

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up wfctl
         uses: GoCodeAlone/setup-wfctl@v1
         with:
-          version: v0.69.5
+          version: v0.73.1
 
       - name: Resolve plugin filter from event
         id: filter

--- a/plugins/aws/manifest.json
+++ b/plugins/aws/manifest.json
@@ -14,6 +14,21 @@
       "aws.credentials",
       "storage.s3"
     ],
+    "serviceMethods": [
+      "workflow.plugin.external.iac.IaCProviderRequired",
+      "workflow.plugin.external.iac.IaCProviderEnumerator",
+      "workflow.plugin.external.iac.IaCProviderDriftDetector",
+      "workflow.plugin.external.iac.IaCProviderCredentialRevoker",
+      "workflow.plugin.external.iac.IaCProviderMigrationRepairer",
+      "workflow.plugin.external.iac.IaCProviderValidator",
+      "workflow.plugin.external.iac.IaCProviderDriftConfigDetector",
+      "workflow.plugin.external.iac.IaCProviderRequirementMapper",
+      "workflow.plugin.external.iac.IaCProviderRegionLister",
+      "workflow.plugin.external.iac.IaCProviderOwnership",
+      "workflow.plugin.external.iac.ResourceDriver",
+      "workflow.plugin.external.iac.IaCProviderRunner",
+      "workflow.plugin.external.iac.IaCStateBackend"
+    ],
     "stepTypes": [
       "step.s3_upload"
     ],
@@ -25,38 +40,32 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "3205a27d1c81752ee928aaac9ddbf2ddc649d774badce00cad42c9689f8cb5e4",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.2.0/workflow-plugin-aws-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "63105ab793db8c23f4b311c7ea2080e6c5dee738900398dcfa33a6eb620165f2",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.2.0/workflow-plugin-aws-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "efa061155af5c0906df256216f1a53df97ee48e6e3a7e7b72cb6151620dbcc75",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.2.0/workflow-plugin-aws-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "dba1b5a2e2167b2f9e6dec02cbd14ee949366bb678718c9602890187dce9c2fd",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.2.0/workflow-plugin-aws-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-linux-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "windows",
-      "sha256": "2fb9b800f3c4a29ad9f158d528c597a5a846abfa2237fe041ee3954683c308ba",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.2.0/workflow-plugin-aws-windows-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-windows-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "windows",
-      "sha256": "afe466f8e6dcb4c37a943ac83d0524ed3d6b650e3a570937c0e290afc69417ac",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.2.0/workflow-plugin-aws-windows-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-windows-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-aws",
@@ -76,7 +85,7 @@
     "s3"
   ],
   "license": "MIT",
-  "minEngineVersion": "0.69.1",
+  "minEngineVersion": "0.73.0",
   "name": "workflow-plugin-aws",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-aws",
@@ -97,5 +106,5 @@
   "status": "experimental",
   "tier": "community",
   "type": "external",
-  "version": "2.2.0"
+  "version": "2.3.0"
 }

--- a/plugins/azure/manifest.json
+++ b/plugins/azure/manifest.json
@@ -12,6 +12,21 @@
     "moduleTypes": [
       "iac.provider"
     ],
+    "serviceMethods": [
+      "workflow.plugin.external.iac.IaCProviderRequired",
+      "workflow.plugin.external.iac.IaCProviderEnumerator",
+      "workflow.plugin.external.iac.IaCProviderDriftDetector",
+      "workflow.plugin.external.iac.IaCProviderCredentialRevoker",
+      "workflow.plugin.external.iac.IaCProviderMigrationRepairer",
+      "workflow.plugin.external.iac.IaCProviderValidator",
+      "workflow.plugin.external.iac.IaCProviderDriftConfigDetector",
+      "workflow.plugin.external.iac.IaCProviderRequirementMapper",
+      "workflow.plugin.external.iac.IaCProviderRegionLister",
+      "workflow.plugin.external.iac.IaCProviderOwnership",
+      "workflow.plugin.external.iac.ResourceDriver",
+      "workflow.plugin.external.iac.IaCProviderRunner",
+      "workflow.plugin.external.iac.IaCStateBackend"
+    ],
     "stepTypes": [],
     "triggerTypes": []
   },
@@ -21,26 +36,22 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "2b5b10874e93251fb89a7401bfda71e0bff9bb9552429b40fc840a32c1b45f55",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.2.0/workflow-plugin-azure-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "793cbf57da78cc072e9efd2edef9205d781d998d99fb68ba77d37ea8f05b51d6",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.2.0/workflow-plugin-azure-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "673bd793336b63d82a889c3b7ca55701057d14a4474e1eceeb664b3a73a94830",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.2.0/workflow-plugin-azure-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "2fdc74ef335a5d3bbe31ccbfa934c130606448b78ea2747715813d59622967f2",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.2.0/workflow-plugin-azure-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-linux-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-azure",
@@ -58,7 +69,7 @@
     "apim"
   ],
   "license": "MIT",
-  "minEngineVersion": "0.69.1",
+  "minEngineVersion": "0.73.0",
   "name": "workflow-plugin-azure",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-azure",
@@ -91,5 +102,5 @@
   "status": "experimental",
   "tier": "community",
   "type": "external",
-  "version": "2.2.0"
+  "version": "2.3.0"
 }

--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -1,23 +1,73 @@
 {
-  "name": "workflow-plugin-gcp",
-  "version": "2.2.0",
-  "description": "GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager",
+  "assets": {
+    "config": true,
+    "ui": false
+  },
   "author": "GoCodeAlone",
-  "license": "MIT",
-  "type": "external",
-  "tier": "community",
-  "private": false,
-  "minEngineVersion": "0.69.1",
-  "required_secrets": [
+  "capabilities": {
+    "configProvider": false,
+    "iacStateBackends": [
+      "gcs"
+    ],
+    "moduleTypes": [
+      "iac.provider",
+      "gcp.credentials",
+      "storage.gcs"
+    ],
+    "serviceMethods": [
+      "workflow.plugin.external.iac.IaCProviderRequired",
+      "workflow.plugin.external.iac.IaCProviderEnumerator",
+      "workflow.plugin.external.iac.IaCProviderDriftDetector",
+      "workflow.plugin.external.iac.IaCProviderCredentialRevoker",
+      "workflow.plugin.external.iac.IaCProviderMigrationRepairer",
+      "workflow.plugin.external.iac.IaCProviderValidator",
+      "workflow.plugin.external.iac.IaCProviderDriftConfigDetector",
+      "workflow.plugin.external.iac.IaCProviderRequirementMapper",
+      "workflow.plugin.external.iac.IaCProviderRegionLister",
+      "workflow.plugin.external.iac.IaCProviderOwnership",
+      "workflow.plugin.external.iac.ResourceDriver",
+      "workflow.plugin.external.iac.IaCProviderRunner",
+      "workflow.plugin.external.iac.IaCStateBackend"
+    ],
+    "stepTypes": [],
+    "triggerTypes": [],
+    "workflowHandlers": []
+  },
+  "category": "infrastructure",
+  "description": "GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager",
+  "downloads": [
     {
-      "name": "GCP_SERVICE_ACCOUNT_JSON",
-      "sensitive": true,
-      "description": "GCP service-account JSON key (inline blob). For the credentials.service_account_json path; ADC / Workload Identity deployments may skip. Referenced as ${GCP_SERVICE_ACCOUNT_JSON}.",
-      "prompt": "GCP service-account JSON"
+      "arch": "amd64",
+      "os": "darwin",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_darwin_amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "darwin",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_darwin_arm64.tar.gz"
+    },
+    {
+      "arch": "amd64",
+      "os": "linux",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_linux_amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "linux",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_linux_arm64.tar.gz"
+    },
+    {
+      "arch": "amd64",
+      "os": "windows",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_windows_amd64.tar.gz"
+    },
+    {
+      "arch": "arm64",
+      "os": "windows",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_windows_arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
-  "repository": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
   "keywords": [
     "gcp",
     "google-cloud",
@@ -29,62 +79,21 @@
     "memorystore",
     "gcs"
   ],
-  "capabilities": {
-    "configProvider": false,
-    "moduleTypes": [
-      "iac.provider",
-      "gcp.credentials",
-      "storage.gcs"
-    ],
-    "stepTypes": [],
-    "triggerTypes": [],
-    "workflowHandlers": [],
-    "iacStateBackends": [
-      "gcs"
-    ]
-  },
-  "assets": {
-    "ui": false,
-    "config": true
-  },
-  "downloads": [
+  "license": "MIT",
+  "minEngineVersion": "0.73.0",
+  "name": "workflow-plugin-gcp",
+  "private": false,
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
+  "required_secrets": [
     {
-      "os": "linux",
-      "arch": "amd64",
-      "sha256": "a98c4af2fcb65a4a6b1197813dfd729ea37bab4693b55911e1438db572aa6fa3",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.2.0/workflow-plugin-gcp_2.2.0_linux_amd64.tar.gz"
-    },
-    {
-      "os": "linux",
-      "arch": "arm64",
-      "sha256": "aabe9b14d0c774046867cc3c45e522b155a89fc19ad6fb761a764294d21cfd5a",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.2.0/workflow-plugin-gcp_2.2.0_linux_arm64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "amd64",
-      "sha256": "6d12f4aa00d52e0a8df64e22fe040ae38b9da8d088cf874bae00cdebb0a6cec6",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.2.0/workflow-plugin-gcp_2.2.0_darwin_amd64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "sha256": "04af86d3c21f5003c423df058c58427d6cc1f7f36a39d6f5ebe61b38f5493a8d",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.2.0/workflow-plugin-gcp_2.2.0_darwin_arm64.tar.gz"
-    },
-    {
-      "os": "windows",
-      "arch": "amd64",
-      "sha256": "b226606ce81186ceceba932da5f4bcc83dd7447bf0476459e2ad7dfc0d2416d8",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.2.0/workflow-plugin-gcp_2.2.0_windows_amd64.tar.gz"
-    },
-    {
-      "os": "windows",
-      "arch": "arm64",
-      "sha256": "fec3dde88cc96e205e4d2b609842cc8f931dbdb24cd983eb23d78bb59493ac40",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.2.0/workflow-plugin-gcp_2.2.0_windows_arm64.tar.gz"
+      "description": "GCP service-account JSON key (inline blob). For the credentials.service_account_json path; ADC / Workload Identity deployments may skip. Referenced as ${GCP_SERVICE_ACCOUNT_JSON}.",
+      "name": "GCP_SERVICE_ACCOUNT_JSON",
+      "prompt": "GCP service-account JSON",
+      "sensitive": true
     }
   ],
   "status": "experimental",
-  "category": "infrastructure"
+  "tier": "community",
+  "type": "external",
+  "version": "2.3.0"
 }


### PR DESCRIPTION
## Summary
- sync AWS, GCP, and Azure manifests to v2.3.0
- advertise workflow.plugin.external.iac.IaCProviderRunner via capabilities.serviceMethods
- update registry sync automation to wfctl v0.73.1 so future syncs preserve capability metadata and parse versioned release assets

## Verification
- bash scripts/validate-manifests.sh
- bash scripts/categorize-manifests.sh --check
- bash tests/test-build-index.sh
- bash tests/test-schema-allowlist-coverage.sh
- GOWORK=off go run ./cmd/wfctl plugin registry-sync readme --check --registry-dir /Users/jon/workspace/workflow-registry/.worktrees/issue-840-iac-provider-runner

Part of GoCodeAlone/workflow#840.