### PR TITLE
chore: preserve IaC plugin download checksums

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up wfctl
         uses: GoCodeAlone/setup-wfctl@v1
         with:
-          version: v0.73.1
+          version: v0.74.1
 
       - name: Resolve plugin filter from event
         id: filter

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up wfctl
         uses: GoCodeAlone/setup-wfctl@v1
         with:
-          version: v0.69.5
+          version: v0.74.1
 
       - name: Validate core plugin manifests
         run: wfctl plugin registry-sync core --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"

--- a/plugins/aws/manifest.json
+++ b/plugins/aws/manifest.json
@@ -40,32 +40,38 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-darwin-amd64.tar.gz",
+      "sha256": "44a1f367b554555a872ec274d9b50d71372d40fa66704c3f806f1cafaf14412c"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-darwin-arm64.tar.gz",
+      "sha256": "1f1043c2addbc1a668873d12b1696c03ab428c32df034425fc072d2235af664b"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-linux-amd64.tar.gz",
+      "sha256": "b9dd1cc9c84498be7cfdea1fc3846a8965900ecc870d6be5dd2069300e8f351c"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-linux-arm64.tar.gz",
+      "sha256": "cd758287001e708456df25e9a5be0199f031c07276627b2beee9f89923cf6f4a"
     },
     {
       "arch": "amd64",
       "os": "windows",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-windows-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-windows-amd64.tar.gz",
+      "sha256": "a7edb03050540ffc3bf6c7d4f81747eddbd9822bf8f8e8c88386d6e19466665a"
     },
     {
       "arch": "arm64",
       "os": "windows",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-windows-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.3.0/workflow-plugin-aws-windows-arm64.tar.gz",
+      "sha256": "a9c072390bc4df2951ff032242db1ebdcc0e6cfe9934c87eb65e0579e0e04a28"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-aws",

--- a/plugins/azure/manifest.json
+++ b/plugins/azure/manifest.json
@@ -36,22 +36,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-darwin-amd64.tar.gz",
+      "sha256": "6a23106ae30da8ab64bb95c012d622f4640b1f1526807123d757465dc70ab809"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-darwin-arm64.tar.gz",
+      "sha256": "1a9824a566b638fdf929e3aea6ede57db1cdd6f8a770493287a83ce4f036f53d"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-linux-amd64.tar.gz",
+      "sha256": "6af99857939e455717c66f2713201c23a044af50e29726b50d013edb8869ef8a"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-azure/releases/download/v2.3.0/workflow-plugin-azure-linux-arm64.tar.gz",
+      "sha256": "2f20caac8623355bb62756461284e13850b88f45f68abdfa5f09528cf3948146"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-azure",

--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -39,32 +39,38 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_darwin_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_darwin_amd64.tar.gz",
+      "sha256": "fba4df93aad472379f9c762b1f0063ac26ea38b78fddbf9f4724954328ebe6ca"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_darwin_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_darwin_arm64.tar.gz",
+      "sha256": "1c7d6c1e3a8f760f4e4de2383000a848aa8fc98b7850e62bbea238bc57992ebb"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_linux_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_linux_amd64.tar.gz",
+      "sha256": "b2392458bc82852e5ba1be453a0ad5ffed80c2ab20e19c053001269843bb6339"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_linux_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_linux_arm64.tar.gz",
+      "sha256": "cfcec6e8ae1452ad76a372bce85f21b1db8acd50f3420475c962348dc18dd0ab"
     },
     {
       "arch": "amd64",
       "os": "windows",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_windows_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_windows_amd64.tar.gz",
+      "sha256": "9b36fc10ba16825e440436d47e03ca62400d48aa6db0c6454e1979852cf24502"
     },
     {
       "arch": "arm64",
       "os": "windows",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_windows_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gcp/releases/download/v2.3.0/workflow-plugin-gcp_2.3.0_windows_arm64.tar.gz",
+      "sha256": "1e9bd74531fd844f0997f5c2f3892fe388d450283d543fbbd9b083d34bf63407"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-gcp",


### PR DESCRIPTION
## Summary
- update registry sync and validation workflows to wfctl v0.74.1
- restore sha256 values for AWS, GCP, and Azure v2.3.0 downloads from published checksums.txt files
- keep IaC runner service metadata from the previous registry sync

## Verification
- bash scripts/validate-manifests.sh
- bash scripts/categorize-manifests.sh --check
- bash tests/test-build-index.sh
- bash tests/test-schema-allowlist-coverage.sh
- GOWORK=off go run ./cmd/wfctl plugin registry-sync readme --check --registry-dir /Users/jon/workspace/workflow-registry/.worktrees/issue-840-checksum-registry

Follow-up to GoCodeAlone/workflow-registry#218 / GoCodeAlone/workflow#840.