### PR TITLE
ci: pin registry actions to Node 24 refs

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: v1
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -22,7 +22,7 @@ jobs:
       group: sync-${{ (github.event_name == 'repository_dispatch' && github.event.action == 'plugin-release' && github.event.client_payload.plugin) || github.event.inputs.plugin || 'all' }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
         if: >-
           !(github.event_name == 'repository_dispatch' && github.event.action == 'plugin-release' && github.event.client_payload.plugin)
           && !(github.event_name == 'workflow_dispatch' && github.event.inputs.plugin)
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: GoCodeAlone/workflow
           path: _workflow
@@ -40,15 +40,15 @@ jobs:
         if: >-
           !(github.event_name == 'repository_dispatch' && github.event.action == 'plugin-release' && github.event.client_payload.plugin)
           && !(github.event_name == 'workflow_dispatch' && github.event.inputs.plugin)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache-dependency-path: _workflow/go.sum
 
       - name: Set up wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
+        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:
-          version: v0.74.1
+          version: v0.74.6
 
       - name: Resolve plugin filter from event
         id: filter

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,12 +13,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install ajv-cli
         run: npm install --global ajv-cli
@@ -36,24 +36,24 @@ jobs:
       contents: read
     steps:
       - name: Check out registry
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check out workflow
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: GoCodeAlone/workflow
           path: _workflow
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26'
+          go-version: '1.26.3'
           cache-dependency-path: _workflow/go.sum
 
       - name: Set up wfctl
-        uses: GoCodeAlone/setup-wfctl@v1
+        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
         with:
-          version: v0.74.1
+          version: v0.74.6
 
       - name: Validate core plugin manifests
         run: wfctl plugin registry-sync core --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"
@@ -67,7 +67,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Validate template YAML files
         run: bash scripts/validate-templates.sh
@@ -78,7 +78,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install jq (Ubuntu ships with it but verify)
         run: |


### PR DESCRIPTION
## Summary
- pin registry workflow actions to immutable commit SHAs with version comments
- upgrade validation to Node 24 and Go 1.26.3
- bump registry wfctl dogfooding from v0.74.1 to v0.74.6

Closes #237

## Verification
- `bash scripts/validate-manifests.sh`
- `bash tests/test-build-index.sh`
- `bash tests/test-schema-allowlist-coverage.sh`
- `bash tests/test-sync-workflow-token.sh`
- `bash tests/test-build-pages-release-token.sh`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
