### PR TITLE
ci: use Node 24 cache action for registry Go jobs

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -43,7 +43,20 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.3'
-          cache-dependency-path: _workflow/go.sum
+          cache: false
+
+      - name: Cache Go modules
+        if: >-
+          !(github.event_name == 'repository_dispatch' && github.event.action == 'plugin-release' && github.event.client_payload.plugin)
+          && !(github.event_name == 'workflow_dispatch' && github.event.inputs.plugin)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-1.26.3-${{ hashFiles('_workflow/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-1.26.3-
 
       - name: Set up wfctl
         uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,7 +48,17 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.3'
-          cache-dependency-path: _workflow/go.sum
+          cache: false
+
+      - name: Cache Go modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-1.26.3-${{ hashFiles('_workflow/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-1.26.3-
 
       - name: Set up wfctl
         uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1


### PR DESCRIPTION
## Summary
- disable setup-go built-in caching so it no longer invokes the hidden Node 20 `actions/cache@v4` path
- add explicit `actions/cache@v5.0.5` pinned by SHA for Go module/build cache
- keep the existing wfctl registry validation and sync behavior unchanged

## Verification
- `bash scripts/validate-manifests.sh`
- `bash tests/test-build-index.sh`
- `bash tests/test-schema-allowlist-coverage.sh`
- `bash tests/test-sync-workflow-token.sh`
- `bash tests/test-build-pages-release-token.sh`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
