### PR TITLE
ci: align registry validation with Go 1.26.4

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: false
 
       - name: Cache Go modules
@@ -56,9 +56,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.26.3-${{ hashFiles('_workflow/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.4-${{ hashFiles('_workflow/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26.3-
+            ${{ runner.os }}-go-1.26.4-
 
       - name: Set up wfctl
         uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1


### PR DESCRIPTION
## Summary
- Align registry validation Go setup and cache keys with Go 1.26.4
- Keep wfctl core registry validation compatible with the current workflow module toolchain

## Root cause
`Validate core manifests against workflow plugins` checks out GoCodeAlone/workflow, then runs `wfctl plugin registry-sync core` under `GOTOOLCHAIN=local`. The workflow module now declares Go 1.26.4, but registry validation was still provisioning Go 1.26.3, causing the inspect build to fail with only `exit status 1`.

## Verification
- `actionlint .github/workflows/*.yml`