### PR TITLE
ci: align registry sync with Go 1.26.4

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -42,7 +42,7 @@ jobs:
           && !(github.event_name == 'workflow_dispatch' && github.event.inputs.plugin)
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
           cache: false
 
       - name: Cache Go modules
@@ -54,9 +54,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-1.26.3-${{ hashFiles('_workflow/go.sum') }}
+          key: ${{ runner.os }}-go-1.26.4-${{ hashFiles('_workflow/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-1.26.3-
+            ${{ runner.os }}-go-1.26.4-
 
       - name: Set up wfctl
         uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1


### PR DESCRIPTION
## Summary
- Align scheduled/full registry sync Go setup and cache keys with Go 1.26.4
- Keep the full-sync `wfctl plugin registry-sync core --fix` path compatible with the current workflow module toolchain

## Verification
- `actionlint .github/workflows/*.yml`