### PR TITLE
chore: sync compute plugin to v0.1.8

### DIFF
--- a/plugins/workflow-plugin-compute/manifest.json
+++ b/plugins/workflow-plugin-compute/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-compute",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Workflow adapter for workflow-compute dispatch, wait, map, provider, pool, catalog, and product-capture workloads",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -40,14 +40,14 @@
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "53e5d60485de99086aaf38fe22dd7d8ee55e1002a16f2f3de25b30a9f8749817",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.7/workflow-plugin-compute-darwin-arm64.tar.gz"
+      "sha256": "6ee1df1d0c2553482e39d6fad886c729ff63aa7213aa4087c93923886dbe34f9",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.8/workflow-plugin-compute-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "c693b5122c65f2a39de36ecbbc5b1bfb1f39e66aa0987725ce86d2e7acd33747",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.7/workflow-plugin-compute-linux-amd64.tar.gz"
+      "sha256": "e0a67783cdea0e8bd3b531c1d8975f290b152affd7a25937b79fbe35df758bcc",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.8/workflow-plugin-compute-linux-amd64.tar.gz"
     }
   ],
   "status": "verified",


### PR DESCRIPTION
## Summary
- update workflow-plugin-compute registry manifest from v0.1.7 to v0.1.8
- point darwin-arm64 and linux-amd64 downloads at the v0.1.8 release assets and digests

## Root cause
The agent setup staging proof failed because projectless `wfctl plugin run --ensure-installed workflow-plugin-compute -- compute agent setup ...` installed v0.1.7 from the default registry. The `agent setup` command shipped in workflow-plugin-compute v0.1.8, but the registry entry had not advanced.

## Verification
- bash scripts/validate-manifests.sh
- bash scripts/categorize-manifests.sh --check
- wfctl plugin registry-sync readme --check --registry-dir .
- bash tests/test-build-index.sh
- git diff --check
