### PR TITLE
fix: harden registry sync workflow

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -59,9 +59,24 @@ jobs:
             ${{ runner.os }}-go-1.26.4-
 
       - name: Set up wfctl
-        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
-        with:
-          version: v0.74.6
+        env:
+          WFCTL_VERSION: v0.78.0
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP}/wfctl-bin"
+          work_dir="${RUNNER_TEMP}/wfctl-download"
+          mkdir -p "${install_dir}" "${work_dir}"
+          base_url="https://github.com/GoCodeAlone/workflow/releases/download/${WFCTL_VERSION}"
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o "${work_dir}/wfctl-linux-amd64" \
+            "${base_url}/wfctl-linux-amd64"
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o "${work_dir}/checksums.txt" \
+            "${base_url}/checksums.txt"
+          (cd "${work_dir}" && grep ' wfctl-linux-amd64$' checksums.txt | sha256sum -c -)
+          install -m 0755 "${work_dir}/wfctl-linux-amd64" "${install_dir}/wfctl"
+          echo "${install_dir}" >> "${GITHUB_PATH}"
+          "${install_dir}/wfctl" version
 
       - name: Resolve plugin filter from event
         id: filter
@@ -120,15 +135,34 @@ jobs:
           PLUGIN:   ${{ steps.filter.outputs.plugin }}
         run: |
           set -euo pipefail
+          run_wfctl() {
+            local attempt max output status
+            max=6
+            for attempt in $(seq 1 "${max}"); do
+              set +e
+              output="$("$@" 2>&1)"
+              status=$?
+              set -e
+              printf '%s\n' "${output}"
+              if [[ ${status} -eq 0 ]] && ! grep -Eq '(^|[[:space:]])ERROR[[:space:]]' <<<"${output}"; then
+                return 0
+              fi
+              if [[ ${attempt} -eq ${max} ]]; then
+                echo "::error::wfctl command failed after ${max} attempts: $*"
+                return 1
+              fi
+              sleep "$((attempt * 10))"
+            done
+          }
           if [[ -n "${PLUGIN}" ]]; then
             echo "syncing single plugin: ${PLUGIN}"
-            wfctl plugin registry-sync --fix --plugin "${PLUGIN}" --registry-dir .
-            wfctl plugin registry-sync readme --registry-dir .
+            run_wfctl wfctl plugin registry-sync --fix --plugin "${PLUGIN}" --registry-dir .
+            run_wfctl wfctl plugin registry-sync readme --registry-dir .
           else
             echo "syncing all plugins (cron / full run)"
-            wfctl plugin registry-sync --fix --registry-dir .
-            wfctl plugin registry-sync core --fix --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"
-            wfctl plugin registry-sync readme --registry-dir .
+            run_wfctl wfctl plugin registry-sync --fix --registry-dir .
+            run_wfctl wfctl plugin registry-sync core --fix --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"
+            run_wfctl wfctl plugin registry-sync readme --registry-dir .
           fi
           if git diff --quiet -- plugins README.md; then
             echo "changed=0" >> "$GITHUB_OUTPUT"
@@ -153,6 +187,25 @@ jobs:
           DISPATCH_ACTION: ${{ github.event.action }}
         run: |
           set -euo pipefail
+          run_wfctl() {
+            local attempt max output status
+            max=6
+            for attempt in $(seq 1 "${max}"); do
+              set +e
+              output="$("$@" 2>&1)"
+              status=$?
+              set -e
+              printf '%s\n' "${output}"
+              if [[ ${status} -eq 0 ]] && ! grep -Eq '(^|[[:space:]])ERROR[[:space:]]' <<<"${output}"; then
+                return 0
+              fi
+              if [[ ${attempt} -eq ${max} ]]; then
+                echo "::error::wfctl command failed after ${max} attempts: $*"
+                return 1
+              fi
+              sleep "$((attempt * 10))"
+            done
+          }
           DATE=$(date +%Y-%m-%d)
 
           if [[ -n "${PLUGIN}" ]]; then
@@ -233,13 +286,15 @@ jobs:
               git clean -fd plugins/ README.md
               git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}"
               git checkout -B "${BRANCH}" "refs/remotes/origin/${BRANCH}"
+              GH_TOKEN="${WFCTL_GH_TOKEN}"
+              export GH_TOKEN
               if [[ -n "${PLUGIN}" ]]; then
-                GH_TOKEN="${WFCTL_GH_TOKEN}" wfctl plugin registry-sync --fix --plugin "${PLUGIN}" --registry-dir .
+                run_wfctl wfctl plugin registry-sync --fix --plugin "${PLUGIN}" --registry-dir .
               else
-                GH_TOKEN="${WFCTL_GH_TOKEN}" wfctl plugin registry-sync --fix --registry-dir .
-                wfctl plugin registry-sync core --fix --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"
+                run_wfctl wfctl plugin registry-sync --fix --registry-dir .
+                run_wfctl wfctl plugin registry-sync core --fix --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"
               fi
-              wfctl plugin registry-sync readme --registry-dir .
+              run_wfctl wfctl plugin registry-sync readme --registry-dir .
               git add plugins/ README.md
               if git diff --cached --quiet; then
                 echo "PR #${existing} already at expected state on re-sync; nothing new to append"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,9 +61,24 @@ jobs:
             ${{ runner.os }}-go-1.26.4-
 
       - name: Set up wfctl
-        uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956 # v1
-        with:
-          version: v0.74.6
+        env:
+          WFCTL_VERSION: v0.78.0
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP}/wfctl-bin"
+          work_dir="${RUNNER_TEMP}/wfctl-download"
+          mkdir -p "${install_dir}" "${work_dir}"
+          base_url="https://github.com/GoCodeAlone/workflow/releases/download/${WFCTL_VERSION}"
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o "${work_dir}/wfctl-linux-amd64" \
+            "${base_url}/wfctl-linux-amd64"
+          curl -fsSL --retry 5 --retry-delay 2 \
+            -o "${work_dir}/checksums.txt" \
+            "${base_url}/checksums.txt"
+          (cd "${work_dir}" && grep ' wfctl-linux-amd64$' checksums.txt | sha256sum -c -)
+          install -m 0755 "${work_dir}/wfctl-linux-amd64" "${install_dir}/wfctl"
+          echo "${install_dir}" >> "${GITHUB_PATH}"
+          "${install_dir}/wfctl" version
 
       - name: Validate core plugin manifests
         run: wfctl plugin registry-sync core --registry-dir . --workflow-repo "$GITHUB_WORKSPACE/_workflow"

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -93,6 +93,11 @@
           "items": { "type": "string" },
           "description": "IaC state-storage backends this plugin's drivers can manage (e.g. spaces, gcs, s3). Provider-specific list — not all IaC providers expose a state backend, so this is separate from iacProvider.resourceTypes."
         },
+        "resourceTypes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Top-level resource types this plugin can manage when it does not publish a nested iacProvider block."
+        },
         "iacProvider": {
           "type": "object",
           "description": "IaC provider declaration — name and supported resource types",

--- a/scripts/build-index.sh
+++ b/scripts/build-index.sh
@@ -86,6 +86,7 @@ while IFS= read -r manifest; do
   # G3-include: capabilities.migrationDrivers
   # G3-include: capabilities.configProvider
   # G3-include: capabilities.iacStateBackends
+  # G3-include: capabilities.resourceTypes
   # G3-exclude: capabilities.serviceMethods — engine-internal gRPC method names, not user-facing search
   # G3-exclude: capabilities.iacProvider.configSchema — large free-form per-resource schema (DO's is ~10KB); per-plugin manifest carries it
   # G3-include: capabilities.iacProvider
@@ -149,6 +150,7 @@ while IFS= read -r manifest; do
       wiringHooks:      (.capabilities.wiringHooks      // []),
       migrationDrivers: (.capabilities.migrationDrivers // []),
       iacStateBackends: (.capabilities.iacStateBackends // []),
+      resourceTypes:    (.capabilities.resourceTypes    // []),
       iacProvider: (
         if .capabilities.iacProvider == null then null
         else {

--- a/tests/fixtures/plugins/foo-iac/manifest.json
+++ b/tests/fixtures/plugins/foo-iac/manifest.json
@@ -15,6 +15,7 @@
   "keywords": ["dns", "iac"],
   "capabilities": {
     "moduleTypes": ["iac.provider.foo"],
+    "resourceTypes": ["infra.provider_root"],
     "configProvider": true,
     "iacStateBackends": ["spaces", "gcs"],
     "serviceMethods": ["foo.collector/query", "foo.collector/stats"],

--- a/tests/test-build-index.sh
+++ b/tests/test-build-index.sh
@@ -69,6 +69,8 @@ assert_jq "foo-iac capabilities.cliCommands[0].subcommands[0].name" \
   '.[] | select(.name=="foo-iac") | .capabilities.cliCommands[0].subcommands[0].name' '"sync"'
 assert_jq "foo-iac capabilities.migrationDrivers" \
   '.[] | select(.name=="foo-iac") | .capabilities.migrationDrivers' '["foo-migrate"]'
+assert_jq "foo-iac capabilities.resourceTypes" \
+  '.[] | select(.name=="foo-iac") | .capabilities.resourceTypes' '["infra.provider_root"]'
 assert_jq "foo-iac iacProvider.computePlanVersion" \
   '.[] | select(.name=="foo-iac") | .iacProvider.computePlanVersion' '"v2"'
 assert_jq "foo-iac required_secrets has 2 items" \


### PR DESCRIPTION
## Summary
- install checksum-verified wfctl v0.78.0 directly in registry sync and validation workflows
- retry wfctl registry-sync commands and fail when wfctl logs ERROR despite a zero exit
- allow and publish direct capabilities.resourceTypes in registry manifests/index output

## Verification
- ruby YAML parse for sync-registry-manifests.yml, validate.yml, build-pages.yml
- unauthenticated curl download of wfctl v0.78.0 plus checksum comparison
- bash scripts/validate-manifests.sh
- bash scripts/categorize-manifests.sh --check
- bash scripts/validate-templates.sh
- bash tests/test-build-index.sh
- bash tests/test-schema-allowlist-coverage.sh
- git diff --check