### PR TITLE
chore: use wfctl v0.78.1 for registry sync

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set up wfctl
         env:
-          WFCTL_VERSION: v0.78.0
+          WFCTL_VERSION: v0.78.1
         run: |
           set -euo pipefail
           install_dir="${RUNNER_TEMP}/wfctl-bin"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Set up wfctl
         env:
-          WFCTL_VERSION: v0.78.0
+          WFCTL_VERSION: v0.78.1
         run: |
           set -euo pipefail
           install_dir="${RUNNER_TEMP}/wfctl-bin"


### PR DESCRIPTION
## Summary
- bump registry sync and validation workflow installs from wfctl v0.78.0 to v0.78.1
- ensures provider registry sync uses the GitHub REST asset-listing fix from workflow#903

## Verification
- ruby YAML parse for sync-registry-manifests.yml, validate.yml, build-pages.yml
- git diff --check