### PR TITLE
Add external GitLab provider registry entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ These plugins are distributed outside the engine repository and are maintained a
 | [twilio](./plugins/twilio/manifest.json) | Comprehensive Twilio integration — SMS, Voice, Verify, Video, Conversations, TaskRouter, and 40+ products | community |
 | [workflow-plugin-atlas-migrate](./plugins/workflow-plugin-atlas-migrate/manifest.json) | Atlas migration driver plugin for the workflow engine: ariga.io/atlas v1 backed Up/Down/Status/Goto with SQL-backed revision tracking and auto-generated atlas.sum | community |
 | [workflow-plugin-compute](./plugins/workflow-plugin-compute/manifest.json) | Workflow adapter for workflow-compute dispatch, wait, map, provider, pool, catalog, and product-capture workloads | community |
+| [workflow-plugin-gitlab](./plugins/workflow-plugin-gitlab/manifest.json) | GitLab integration plugin: webhook handling and GitLab CI pipeline management | community |
 | [workflow-plugin-infra](./plugins/workflow-plugin-infra/manifest.json) | Abstract infra.* module types with IaCProvider delegation + dynamic plan/apply SPA, exec-env, and reconcile (plugs into workflow-plugin-admin) | community |
 | [workflow-plugin-migrations](./plugins/workflow-plugin-migrations/manifest.json) | Database migration plugin for the workflow engine: golang-migrate + goose drivers, pre-deploy runner, wfctl migrate CLI, static lint tool, and tenant-ensure schema setup | community |
 | [workflow-plugin-product-capture](./plugins/workflow-plugin-product-capture/manifest.json) | Product URL capture provider for workflow-compute | community |

--- a/plugins/payments/manifest.json
+++ b/plugins/payments/manifest.json
@@ -8,7 +8,7 @@
     "cliCommands": [
       {
         "description": "Payment provider operations (webhook ensure, …)",
-        "flagsPassthrough": true,
+        "flags_passthrough": true,
         "name": "payments"
       }
     ],

--- a/plugins/workflow-plugin-gitlab/manifest.json
+++ b/plugins/workflow-plugin-gitlab/manifest.json
@@ -1,0 +1,130 @@
+{
+  "name": "workflow-plugin-gitlab",
+  "version": "1.1.1",
+  "description": "GitLab integration plugin: webhook handling and GitLab CI pipeline management",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "status": "experimental",
+  "category": "integrations",
+  "minEngineVersion": "0.53.0",
+  "keywords": [
+    "gitlab",
+    "webhook",
+    "git",
+    "ci",
+    "cd",
+    "pipeline",
+    "merge-request",
+    "integration"
+  ],
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-gitlab",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-gitlab",
+  "source": "github.com/GoCodeAlone/workflow-plugin-gitlab",
+  "required_secrets": [
+    {
+      "name": "GITLAB_TOKEN",
+      "sensitive": true,
+      "description": "GitLab personal, project, or group access token with API permissions for pipeline, merge-request, CI/CD variable, and environment management operations.",
+      "prompt": "GitLab API token"
+    }
+  ],
+  "secret_targets": [
+    {
+      "provider": "gitlab",
+      "scopes": ["project", "group", "env"],
+      "description": "GitLab CI/CD variables at project, group, and environment scope."
+    },
+    {
+      "provider": "github",
+      "scopes": ["repo", "env", "org"],
+      "description": "GitLab token stored as GitHub Actions secrets when workflows run on GitHub."
+    },
+    {
+      "provider": "vault",
+      "scopes": ["mount"],
+      "description": "GitLab token stored in Vault for application/runtime retrieval."
+    },
+    {
+      "provider": "file",
+      "scopes": ["directory"],
+      "description": "GitLab token stored in a local file-backed secret store."
+    },
+    {
+      "provider": "keychain",
+      "scopes": ["service"],
+      "description": "GitLab token stored in the local OS keychain."
+    },
+    {
+      "provider": "env",
+      "scopes": ["process"],
+      "description": "GitLab token provided by the local process environment."
+    }
+  ],
+  "downloads": [
+    {
+      "os": "darwin",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.1.1/workflow-plugin-gitlab-darwin-amd64.tar.gz",
+      "sha256": "1666d2ee8655fef07fea994a4a3d4c7ecbfb45197d6fc899e1523da892f46f5c"
+    },
+    {
+      "os": "darwin",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.1.1/workflow-plugin-gitlab-darwin-arm64.tar.gz",
+      "sha256": "31139cef74a86e28ebde30dee43a7cc9f0b8359b27a35f68462585cdd00bb6f6"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.1.1/workflow-plugin-gitlab-linux-amd64.tar.gz",
+      "sha256": "a7dd6dd3f769b4f49b2bcff3745377c1955d5ccf71a10036367302ae1d5ec7f2"
+    },
+    {
+      "os": "linux",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.1.1/workflow-plugin-gitlab-linux-arm64.tar.gz",
+      "sha256": "305cd4b741a7b913a49e918b568cc49a05436790e6b1e1d4cfda03e8a28e58ab"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.1.1/workflow-plugin-gitlab-windows-amd64.tar.gz",
+      "sha256": "a0446972e31fc2633899fe36dd906493fb4062070866023445440d2e817f769c"
+    },
+    {
+      "os": "windows",
+      "arch": "arm64",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-gitlab/releases/download/v1.1.1/workflow-plugin-gitlab-windows-arm64.tar.gz",
+      "sha256": "b3dd712e21dd26a9baf79e6a9335505ad0b22ea0bcee456a0dfe9f6d3d5ef57e"
+    }
+  ],
+  "capabilities": {
+    "configProvider": false,
+    "moduleTypes": [
+      "git.webhook",
+      "gitlab.webhook",
+      "gitlab.client"
+    ],
+    "stepTypes": [
+      "step.gitlab_trigger_pipeline",
+      "step.gitlab_pipeline_status",
+      "step.gitlab_create_merge_request",
+      "step.gitlab_create_mr",
+      "step.gitlab_mr_comment",
+      "step.gitlab_parse_webhook",
+      "step.gitlab_secret_set",
+      "step.gitlab_secret_list",
+      "step.gitlab_environment_ensure",
+      "step.gitlab_environment_list"
+    ],
+    "serviceMethods": [
+      "gitlab.client/trigger_pipeline",
+      "gitlab.client/pipeline_status",
+      "gitlab.client/create_merge_request",
+      "gitlab.client/mr_comment"
+    ],
+    "triggerTypes": []
+  }
+}

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -343,6 +343,30 @@
         },
         "additionalProperties": false
       }
+    },
+    "secret_targets": {
+      "type": "array",
+      "description": "Secret provider targets this plugin supports. Consumed by wfctl to present provider-owned scopes such as GitHub repo/org/env, GitLab project/group/env, Vault mount, or local file-backed stores.",
+      "items": {
+        "type": "object",
+        "required": ["provider", "scopes"],
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Canonical secret provider name (e.g. github, gitlab, vault, file, keychain, env)"
+          },
+          "scopes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Provider-owned scope identifiers supported by this target"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable target description shown by wfctl"
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/scripts/build-index.sh
+++ b/scripts/build-index.sh
@@ -77,6 +77,10 @@ while IFS= read -r manifest; do
   # G3-include: dependencies.minVersion
   # G3-include: dependencies.maxVersion
   # G3-include: required_secrets
+  # G3-include: secret_targets
+  # G3-include: secret_targets.provider
+  # G3-include: secret_targets.scopes
+  # G3-include: secret_targets.description
   # G3-include: capabilities
   # G3-include: capabilities.moduleTypes
   # G3-include: capabilities.stepTypes
@@ -192,6 +196,16 @@ while IFS= read -r manifest; do
       sensitive:   (.sensitive // false),
       description: (.description // null),
       prompt:      (.prompt // null)
+    }]}
+    end
+  )
+  +
+  (
+    if (.secret_targets // null) == null then {}
+    else { secret_targets: [.secret_targets[] | {
+      provider:    (.provider // null),
+      scopes:      (.scopes // []),
+      description: (.description // null)
     }]}
     end
   ))' "${manifest}")"

--- a/scripts/categorize-manifests.sh
+++ b/scripts/categorize-manifests.sh
@@ -103,6 +103,7 @@ declare -A CATEGORY_MAP=(
   [workflow-plugin-atlas-migrate]="data"
   [workflow-plugin-auth]="core"
   [workflow-plugin-compute]="core"
+  [workflow-plugin-gitlab]="integrations"
   [workflow-plugin-migrations]="data"
   [workflow-plugin-product-capture]="core"
   [workflow-plugin-supply-chain]="security"

--- a/tests/fixtures/plugins/foo-iac/manifest.json
+++ b/tests/fixtures/plugins/foo-iac/manifest.json
@@ -51,6 +51,14 @@
     {"name": "FOO_USER", "sensitive": false, "description": "Foo username"},
     {"name": "FOO_PASS", "sensitive": true, "description": "Foo password"}
   ],
+  "secret_targets": [
+    {
+      "provider": "github",
+      "scopes": ["repo", "env"],
+      "description": "Foo credentials stored in GitHub Actions secrets",
+      "target_leak": "should_not_appear"
+    }
+  ],
   "assets": {"ui": false, "config": true, "assets_leak": "should_not_appear"},
   "dependencies": [
     {

--- a/tests/test-build-index.sh
+++ b/tests/test-build-index.sh
@@ -75,6 +75,12 @@ assert_jq "foo-iac iacProvider.computePlanVersion" \
   '.[] | select(.name=="foo-iac") | .iacProvider.computePlanVersion' '"v2"'
 assert_jq "foo-iac required_secrets has 2 items" \
   '.[] | select(.name=="foo-iac") | .required_secrets | length' '2'
+assert_jq "foo-iac secret_targets has 1 item" \
+  '.[] | select(.name=="foo-iac") | .secret_targets | length' '1'
+assert_jq "foo-iac secret_targets[0].provider" \
+  '.[] | select(.name=="foo-iac") | .secret_targets[0].provider' '"github"'
+assert_jq "foo-iac secret_targets[0].scopes" \
+  '.[] | select(.name=="foo-iac") | .secret_targets[0].scopes' '["repo","env"]'
 
 # === Empty-array preservation ===
 assert_jq "bar-simple required_secrets preserved as []" \
@@ -90,11 +96,22 @@ assert_jq "qux-no-secrets is present in index" \
 if jq -e '.[] | select(.name=="qux-no-secrets") | has("required_secrets")' "${INDEX}" >/dev/null; then
   fail "qux-no-secrets should have no required_secrets key (manifest omits it); C-1 regression"
 fi
+if jq -e '.[] | select(.name=="qux-no-secrets") | has("secret_targets")' "${INDEX}" >/dev/null; then
+  fail "qux-no-secrets should have no secret_targets key (manifest omits it)"
+fi
 
 # === required_secrets per-item allowlist (extras dropped) ===
 assert_jq "required_secrets[0] item has exactly 4 known keys" \
   '.[] | select(.name=="foo-iac") | .required_secrets[0] | keys_unsorted | sort' \
   '["description","name","prompt","sensitive"]'
+
+# === secret_targets per-item allowlist (extras dropped) ===
+assert_jq "secret_targets[0] item has exactly 3 known keys" \
+  '.[] | select(.name=="foo-iac") | .secret_targets[0] | keys_unsorted | sort' \
+  '["description","provider","scopes"]'
+if jq -e '.[] | select(.name=="foo-iac") | .secret_targets[0] | has("target_leak")' "${INDEX}" >/dev/null; then
+  fail "G3 allowlist regression: secret_targets item leaked sub-field 'target_leak'"
+fi
 
 # === Per-item allowlist on cliCommands (extras dropped) ===
 assert_jq "cliCommands item has exactly 4 known keys" \

--- a/tests/test-schema-allowlist-coverage.sh
+++ b/tests/test-schema-allowlist-coverage.sh
@@ -19,6 +19,7 @@
 #   - iacProvider.* (top-level — name, resourceTypes, computePlanVersion)
 #   - assets.* (ui, config) — added round 2 per Copilot
 #   - dependencies.items.* (name, minVersion, maxVersion) — added round 2 per Copilot
+#   - secret_targets.items.* (provider, scopes, description)
 
 set -euo pipefail
 
@@ -58,7 +59,8 @@ schema_props() {
       ((.properties.capabilities.properties.cliCommands.items.properties.subcommands.items.properties // {}) | keys[] | "capabilities.cliCommands.subcommands." + .),
       ((.properties.iacProvider.properties // {}) | keys[] | "iacProvider." + .),
       ((.properties.assets.properties // {}) | keys[] | "assets." + .),
-      ((.properties.dependencies.items.properties // {}) | keys[] | "dependencies." + .)
+      ((.properties.dependencies.items.properties // {}) | keys[] | "dependencies." + .),
+      ((.properties.secret_targets.items.properties // {}) | keys[] | "secret_targets." + .)
     ] | .[]
   ' "${SCHEMA}" | sort -u
 }


### PR DESCRIPTION
## Summary
- add `workflow-plugin-gitlab` as a distinct external registry entry, leaving the builtin `gitlab` manifest unchanged
- publish GitLab provider `secret_targets` for project/group/env plus supported storage targets
- extend the registry schema and public index allowlist for `secret_targets`
- normalize the payments manifest `flags_passthrough` field so full manifest validation passes

## Verification
- `bash scripts/validate-manifests.sh`
- `bash scripts/categorize-manifests.sh --check`
- `bash scripts/validate-templates.sh`
- `bash tests/test-build-index.sh`
- `bash tests/test-schema-allowlist-coverage.sh`
- `git diff --check`
- `bash scripts/build-index.sh` smoke: generated index includes `workflow-plugin-gitlab` with GitLab/GitHub/Vault/file/keychain/env secret targets

Follow-up discovered while testing: `wfctl plugin registry-sync --fix` treats an empty downloads list as matching when the version is already current, so this PR manually adds the released v1.1.1 asset URLs/checksums. I will fix that in workflow next so future new external plugin manifests populate downloads automatically.