### PR TITLE
Optimize registry version generation

### DIFF
--- a/scripts/build-versions.sh
+++ b/scripts/build-versions.sh
@@ -7,17 +7,17 @@
 # Requires: gh CLI (authenticated), jq
 #
 # Notes:
-#   - `gh release list` does NOT support --json assets; per-release assets are
-#     fetched via `gh release view <tag> --json assets`.
+#   - GitHub's REST releases list includes release assets, so each upstream repo
+#     is fetched once and reused for all registry plugins that share it.
 #   - Asset digests (sha256) are read directly from the `digest` field returned
-#     by `gh release view`, so checksums.txt does not need to be downloaded.
+#     by the API, so checksums.txt does not need to be downloaded.
 #   - The canonical plugin name used in versions.json is the directory name
 #     (same convention as build-index.sh), not the manifest's "name" field.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 PLUGINS_DIR="${REPO_ROOT}/plugins"
 OUT_DIR="${REPO_ROOT}/v1"
 
@@ -69,20 +69,21 @@ while IFS= read -r manifest; do
   repo_cache_dir="${release_cache_root}/$(echo "${gh_repo}" | tr '/:' '__')"
   mkdir -p "${repo_cache_dir}"
 
-  echo "  ${plugin_name}: fetching releases for ${gh_repo}..."
-
-  # List releases (tagName + publishedAt only; assets not available in list output)
+  # List releases and their assets in one REST call per upstream repo.
   releases_cache="${repo_cache_dir}/releases.json"
   if [[ ! -f "${releases_cache}" ]]; then
-    if ! releases_list="$(run_gh release list \
-      --repo "${gh_repo}" \
-      --limit 100 \
-      --json tagName,publishedAt \
-      2>&1)"; then
-      echo "    WARNING: failed to list releases for ${gh_repo}: ${releases_list}" >&2
+    echo "  ${plugin_name}: fetching releases for ${gh_repo}..."
+    releases_error="${repo_cache_dir}/releases.err"
+    if ! releases_list="$(run_gh api \
+      "repos/${gh_repo}/releases?per_page=100" \
+      2>"${releases_error}")"; then
+      echo "    WARNING: failed to list releases for ${gh_repo}: $(cat "${releases_error}")" >&2
       releases_list="[]"
     fi
+    rm -f "${releases_error}"
     printf '%s\n' "${releases_list}" > "${releases_cache}"
+  else
+    echo "  ${plugin_name}: using cached releases for ${gh_repo}..."
   fi
   releases_list="$(cat "${releases_cache}")"
 
@@ -97,27 +98,12 @@ while IFS= read -r manifest; do
   final_versions_file="${release_cache_root}/versions-$(echo "${plugin_name}" | sed 's/[^A-Za-z0-9._-]/_/g').json"
   printf '[]\n' > "${final_versions_file}"
   while IFS= read -r release_entry; do
-    tag="$(echo "${release_entry}" | jq -r '.tagName')"
-    published_at="$(echo "${release_entry}" | jq -r '.publishedAt')"
+    tag="$(echo "${release_entry}" | jq -r '.tag_name // .tagName')"
+    published_at="$(echo "${release_entry}" | jq -r '.published_at // .publishedAt')"
     ver="$(echo "${tag}" | sed 's/^v//')"
 
-    # gh release view returns assets with a `digest` field (sha256:... format)
-    tag_cache_key="$(echo "${tag}" | sed 's/[^A-Za-z0-9._-]/_/g')"
-    release_detail_cache="${repo_cache_dir}/${tag_cache_key}.json"
-    if [[ ! -f "${release_detail_cache}" ]]; then
-      if ! release_detail="$(run_gh release view "${tag}" \
-        --repo "${gh_repo}" \
-        --json assets \
-        2>&1)"; then
-        echo "    WARNING: failed to fetch assets for ${gh_repo}@${tag}: ${release_detail}" >&2
-        release_detail='{"assets":[]}'
-      fi
-      printf '%s\n' "${release_detail}" > "${release_detail_cache}"
-    fi
-    release_detail="$(cat "${release_detail_cache}")"
-
     version_entry_file="${release_cache_root}/version-entry-$(echo "${plugin_name}-${tag}" | sed 's/[^A-Za-z0-9._-]/_/g').json"
-    echo "${release_detail}" | jq \
+    echo "${release_entry}" | jq \
       --arg ver "${ver}" \
       --arg published_at "${published_at}" \
       --arg minEng "${min_engine}" '
@@ -126,15 +112,15 @@ while IFS= read -r manifest; do
         released: $published_at,
         minEngineVersion: (if $minEng != "" then $minEng else null end),
         downloads: [
-          .assets[] |
+          (.assets // [])[] |
           select(.name | test("(linux|darwin|windows)-(amd64|arm64)[.]tar[.]gz$")) |
           . as $asset |
           ($asset.name | capture("(?<os>linux|darwin|windows)-(?<arch>amd64|arm64)[.]tar[.]gz$")) as $parts |
           {
             os:     $parts.os,
             arch:   $parts.arch,
-            url:    $asset.url,
-            sha256: ($asset.digest | if . then ltrimstr("sha256:") else "" end)
+            url:    ($asset.browser_download_url // $asset.url // ""),
+            sha256: (($asset.digest // "") | ltrimstr("sha256:"))
           }
         ]
       }

--- a/tests/test-build-versions.sh
+++ b/tests/test-build-versions.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# tests/test-build-versions.sh
+#
+# Regression coverage for scripts/build-versions.sh. The version builder should
+# fetch GitHub release metadata and assets in one cached REST call per upstream
+# repo, preserving the public versions.json/latest.json contract.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT_REAL="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if ! command -v jq &>/dev/null; then
+  echo "error: jq required" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+mkdir -p "${tmp}/scripts" \
+  "${tmp}/plugins/plugin-alpha" \
+  "${tmp}/plugins/plugin-beta" \
+  "${tmp}/plugins/plugin-local" \
+  "${tmp}/bin"
+
+cp "${REPO_ROOT_REAL}/scripts/build-versions.sh" "${tmp}/scripts/build-versions.sh"
+
+cat > "${tmp}/plugins/plugin-alpha/manifest.json" <<'JSON'
+{
+  "name": "plugin-alpha",
+  "repository": "https://github.com/example/shared-plugin",
+  "minEngineVersion": "0.75.0"
+}
+JSON
+
+cat > "${tmp}/plugins/plugin-beta/manifest.json" <<'JSON'
+{
+  "name": "plugin-beta",
+  "repository": "https://github.com/example/shared-plugin.git",
+  "minEngineVersion": "0.76.0"
+}
+JSON
+
+cat > "${tmp}/plugins/plugin-local/manifest.json" <<'JSON'
+{
+  "name": "plugin-local",
+  "repository": "https://gitlab.com/example/plugin-local"
+}
+JSON
+
+calls_file="${tmp}/gh-api-calls"
+: > "${calls_file}"
+
+cat > "${tmp}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" != "api" ]]; then
+  echo "unexpected gh invocation: gh $*" >&2
+  exit 42
+fi
+
+endpoint="$2"
+case "${endpoint}" in
+  repos/example/shared-plugin/releases\?per_page=100)
+    printf '%s\n' "${endpoint}" >> "${GH_CALLS_FILE}"
+    cat <<'JSON'
+[
+  {
+    "tag_name": "v1.2.3",
+    "published_at": "2026-06-01T12:00:00Z",
+    "assets": [
+      {
+        "name": "workflow-plugin-shared-linux-amd64.tar.gz",
+        "browser_download_url": "https://downloads.example/shared/v1.2.3/linux-amd64.tar.gz",
+        "url": "https://api.github.com/repos/example/shared-plugin/releases/assets/1",
+        "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      {
+        "name": "workflow-plugin-shared-darwin-arm64.tar.gz",
+        "browser_download_url": "https://downloads.example/shared/v1.2.3/darwin-arm64.tar.gz",
+        "url": "https://api.github.com/repos/example/shared-plugin/releases/assets/2",
+        "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      {
+        "name": "checksums.txt",
+        "browser_download_url": "https://downloads.example/shared/v1.2.3/checksums.txt",
+        "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    ]
+  },
+  {
+    "tag_name": "v1.2.2",
+    "published_at": "2026-05-01T12:00:00Z",
+    "assets": [
+      {
+        "name": "workflow-plugin-shared-windows-amd64.tar.gz",
+        "browser_download_url": "https://downloads.example/shared/v1.2.2/windows-amd64.tar.gz",
+        "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      }
+    ]
+  }
+]
+JSON
+    ;;
+  *)
+    echo "unexpected gh api endpoint: ${endpoint}" >&2
+    exit 43
+    ;;
+esac
+SH
+chmod +x "${tmp}/bin/gh"
+
+GH_CALLS_FILE="${calls_file}" PATH="${tmp}/bin:${PATH}" \
+  bash "${tmp}/scripts/build-versions.sh" >/dev/null
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_jq_file() {
+  local desc="$1" file="$2" expr="$3" expected="$4"
+  local actual
+  actual="$(jq -c "${expr}" "${file}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    fail "${desc}: expected ${expected}, got ${actual}"
+  fi
+}
+
+alpha_versions="${tmp}/v1/plugins/plugin-alpha/versions.json"
+alpha_latest="${tmp}/v1/plugins/plugin-alpha/latest.json"
+beta_latest="${tmp}/v1/plugins/plugin-beta/latest.json"
+local_versions="${tmp}/v1/plugins/plugin-local/versions.json"
+
+test -f "${alpha_versions}" || fail "plugin-alpha versions.json missing"
+test -f "${alpha_latest}" || fail "plugin-alpha latest.json missing"
+test -f "${beta_latest}" || fail "plugin-beta latest.json missing"
+test -f "${local_versions}" || fail "plugin-local versions.json missing"
+
+assert_jq_file "alpha versions has two releases" "${alpha_versions}" '.versions | length' '2'
+assert_jq_file "alpha latest version" "${alpha_latest}" '.version' '"1.2.3"'
+assert_jq_file "alpha min engine propagated" "${alpha_latest}" '.minEngineVersion' '"0.75.0"'
+assert_jq_file "matching assets only" "${alpha_latest}" '.downloads | length' '2'
+assert_jq_file "download URL uses browser_download_url" "${alpha_latest}" \
+  '.downloads[] | select(.os=="linux" and .arch=="amd64") | .url' \
+  '"https://downloads.example/shared/v1.2.3/linux-amd64.tar.gz"'
+assert_jq_file "sha256 prefix stripped" "${alpha_latest}" \
+  '.downloads[] | select(.os=="linux" and .arch=="amd64") | .sha256' \
+  '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'
+assert_jq_file "beta reuses same release data with its own min engine" "${beta_latest}" \
+  '.minEngineVersion' '"0.76.0"'
+assert_jq_file "non-GitHub plugin writes empty versions" "${local_versions}" \
+  '.versions' '[]'
+
+api_calls="$(wc -l < "${calls_file}" | tr -d ' ')"
+if [[ "${api_calls}" != "1" ]]; then
+  fail "expected one gh api call for shared upstream repo, got ${api_calls}"
+fi
+
+echo "OK - test-build-versions.sh passed"


### PR DESCRIPTION
## Summary
- Fetch GitHub releases and embedded assets with one REST API call per upstream repo instead of one list call plus one detail call per release tag.
- Reuse cached release payloads for plugins that point at the same GitHub repo.
- Preserve the existing `v1/plugins/<name>/versions.json` and `latest.json` shape, using browser download URLs and stripped SHA256 digests.
- Add regression coverage for shared-repo caching and output contract.

Fixes #281.

## Verification
- RED: with the production fix reverted, `bash tests/test-build-versions.sh` failed because the old implementation invoked `gh release list --repo example/shared-plugin --limit 100 --json tagName,publishedAt`; the fake gh rejected that and `plugin-alpha latest.json` was missing.
- GREEN: `bash tests/test-build-versions.sh` -> `OK - test-build-versions.sh passed`.
- `bash tests/test-build-index.sh` -> passed.
- `bash tests/test-schema-allowlist-coverage.sh` -> passed.
- `bash scripts/validate-manifests.sh` -> `All plugin manifests are valid.`
- `bash scripts/categorize-manifests.sh --check` -> passed.
- `bash scripts/validate-templates.sh` -> passed.
- `bash scripts/build-index.sh && bash scripts/build-versions.sh` -> completed; live sample `v1/plugins/workflow-plugin-gitlab/latest.json` used GitHub browser download URLs and stripped SHA256 digests.
- `git diff --check` -> clean.

Doc-reconciliation: clean.