### PR TITLE
Support underscore release asset names

### DIFF
--- a/scripts/build-versions.sh
+++ b/scripts/build-versions.sh
@@ -113,9 +113,9 @@ while IFS= read -r manifest; do
         minEngineVersion: (if $minEng != "" then $minEng else null end),
         downloads: [
           (.assets // [])[] |
-          select(.name | test("(linux|darwin|windows)-(amd64|arm64)[.]tar[.]gz$")) |
+          select(.name | test("(linux|darwin|windows)[-_](amd64|arm64)[.]tar[.]gz$")) |
           . as $asset |
-          ($asset.name | capture("(?<os>linux|darwin|windows)-(?<arch>amd64|arm64)[.]tar[.]gz$")) as $parts |
+          ($asset.name | capture("(?<os>linux|darwin|windows)[-_](?<arch>amd64|arm64)[.]tar[.]gz$")) as $parts |
           {
             os:     $parts.os,
             arch:   $parts.arch,

--- a/tests/test-build-versions.sh
+++ b/tests/test-build-versions.sh
@@ -84,6 +84,12 @@ case "${endpoint}" in
         "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
       },
       {
+        "name": "workflow-plugin-shared_1.2.3_windows_arm64.tar.gz",
+        "browser_download_url": "https://downloads.example/shared/v1.2.3/windows-arm64.tar.gz",
+        "url": "https://api.github.com/repos/example/shared-plugin/releases/assets/3",
+        "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      },
+      {
         "name": "checksums.txt",
         "browser_download_url": "https://downloads.example/shared/v1.2.3/checksums.txt",
         "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -138,13 +144,19 @@ test -f "${local_versions}" || fail "plugin-local versions.json missing"
 assert_jq_file "alpha versions has two releases" "${alpha_versions}" '.versions | length' '2'
 assert_jq_file "alpha latest version" "${alpha_latest}" '.version' '"1.2.3"'
 assert_jq_file "alpha min engine propagated" "${alpha_latest}" '.minEngineVersion' '"0.75.0"'
-assert_jq_file "matching assets only" "${alpha_latest}" '.downloads | length' '2'
+assert_jq_file "matching assets only" "${alpha_latest}" '.downloads | length' '3'
 assert_jq_file "download URL uses browser_download_url" "${alpha_latest}" \
   '.downloads[] | select(.os=="linux" and .arch=="amd64") | .url' \
   '"https://downloads.example/shared/v1.2.3/linux-amd64.tar.gz"'
 assert_jq_file "sha256 prefix stripped" "${alpha_latest}" \
   '.downloads[] | select(.os=="linux" and .arch=="amd64") | .sha256' \
   '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"'
+assert_jq_file "underscore asset names are parsed" "${alpha_latest}" \
+  '.downloads[] | select(.os=="windows" and .arch=="arm64") | .url' \
+  '"https://downloads.example/shared/v1.2.3/windows-arm64.tar.gz"'
+assert_jq_file "underscore asset sha256 prefix stripped" "${alpha_latest}" \
+  '.downloads[] | select(.os=="windows" and .arch=="arm64") | .sha256' \
+  '"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"'
 assert_jq_file "beta reuses same release data with its own min engine" "${beta_latest}" \
   '.minEngineVersion' '"0.76.0"'
 assert_jq_file "non-GitHub plugin writes empty versions" "${local_versions}" \


### PR DESCRIPTION
## Summary
- Parse both hyphenated (`linux-amd64`) and GoReleaser underscore (`linux_amd64`) release asset suffixes when generating plugin version downloads.
- Extend `tests/test-build-versions.sh` with an underscore-style asset fixture and assertions.

Fixes #283.

## Verification
- RED: current parser failed `bash tests/test-build-versions.sh` with `matching assets only: expected 3, got 2`.
- GREEN: `bash tests/test-build-versions.sh` -> `OK - test-build-versions.sh passed`.
- Regression proof: with only the parser fix reverted, `bash tests/test-build-versions.sh` failed with `expected 3, got 2`; restored parser passed.
- `bash tests/test-build-index.sh` -> passed.
- `bash tests/test-schema-allowlist-coverage.sh` -> passed.
- `bash scripts/validate-manifests.sh` -> `All plugin manifests are valid.`
- `bash scripts/categorize-manifests.sh --check` -> passed.
- `bash scripts/validate-templates.sh` -> passed.
- `bash scripts/build-index.sh && bash scripts/build-versions.sh` -> completed; generated `v1/plugins/workflow-plugin-infra/latest.json` had `downloadCount: 6` for v1.2.1 underscore assets.
- `git diff --check` -> clean.

Doc-reconciliation: clean.