### PR TITLE
fix: publish env setup metadata in registry

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set up wfctl
         env:
-          WFCTL_VERSION: v0.78.1
+          WFCTL_VERSION: v0.80.6
         run: |
           set -euo pipefail
           install_dir="${RUNNER_TEMP}/wfctl-bin"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Set up wfctl
         env:
-          WFCTL_VERSION: v0.78.1
+          WFCTL_VERSION: v0.80.6
         run: |
           set -euo pipefail
           install_dir="${RUNNER_TEMP}/wfctl-bin"

--- a/plugins/aws/manifest.json
+++ b/plugins/aws/manifest.json
@@ -35,6 +35,39 @@
     "triggerTypes": []
   },
   "category": "infrastructure",
+  "config_targets": [
+    {
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in a local dotenv/config file for local workflows.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "description": "AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, and ACM resources",
   "downloads": [
     {
@@ -95,18 +128,75 @@
   "name": "workflow-plugin-aws",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-aws",
-  "required_secrets": [
+  "required_config": [
     {
-      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID} in the iac.provider/aws config.",
+      "description": "AWS region for provider operations and config templates. Referenced as ${AWS_REGION}.",
+      "key": "region",
+      "name": "AWS_REGION",
+      "prompt": "AWS region",
+      "sensitive": false
+    },
+    {
+      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID}.",
+      "key": "access_key_id",
       "name": "AWS_ACCESS_KEY_ID",
       "prompt": "AWS access key ID",
-      "sensitive": true
-    },
+      "sensitive": false
+    }
+  ],
+  "required_secrets": [
     {
       "description": "AWS secret access key (pairs with AWS_ACCESS_KEY_ID). Referenced as ${AWS_SECRET_ACCESS_KEY}.",
       "name": "AWS_SECRET_ACCESS_KEY",
       "prompt": "AWS secret access key",
       "sensitive": true
+    }
+  ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
     }
   ],
   "status": "experimental",

--- a/plugins/azure/manifest.json
+++ b/plugins/azure/manifest.json
@@ -31,6 +31,39 @@
     "triggerTypes": []
   },
   "category": "infrastructure",
+  "config_targets": [
+    {
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in a local dotenv/config file for local workflows.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "description": "Microsoft Azure infrastructure provider: ACI, AKS, SQL, Redis, VNet, LB, DNS, ACR, APIM, NSG, MSI, Blob Storage, App Service Certificates",
   "downloads": [
     {
@@ -77,30 +110,82 @@
   "name": "workflow-plugin-azure",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-azure",
-  "required_secrets": [
+  "required_config": [
     {
-      "description": "Azure AD app (service principal) client ID for DefaultAzureCredential. Referenced as ${AZURE_CLIENT_ID}.",
-      "name": "AZURE_CLIENT_ID",
-      "prompt": "Azure client ID",
+      "description": "Azure subscription ID for IaC operations. Referenced as ${AZURE_SUBSCRIPTION_ID}.",
+      "key": "subscription_id",
+      "name": "AZURE_SUBSCRIPTION_ID",
+      "prompt": "Azure subscription ID",
       "sensitive": false
     },
     {
-      "description": "Azure AD app client secret. Referenced as ${AZURE_CLIENT_SECRET}.",
-      "name": "AZURE_CLIENT_SECRET",
-      "prompt": "Azure client secret",
-      "sensitive": true
-    },
-    {
       "description": "Azure AD tenant ID. Referenced as ${AZURE_TENANT_ID}.",
+      "key": "tenant_id",
       "name": "AZURE_TENANT_ID",
       "prompt": "Azure tenant ID",
       "sensitive": false
     },
     {
-      "description": "Azure subscription ID for IaC operations. Referenced as ${AZURE_SUBSCRIPTION_ID}.",
-      "name": "AZURE_SUBSCRIPTION_ID",
-      "prompt": "Azure subscription ID",
+      "description": "Azure AD app (service principal) client ID for DefaultAzureCredential. Referenced as ${AZURE_CLIENT_ID}.",
+      "key": "client_id",
+      "name": "AZURE_CLIENT_ID",
+      "prompt": "Azure client ID",
       "sensitive": false
+    }
+  ],
+  "required_secrets": [
+    {
+      "description": "Azure AD app client secret. Referenced as ${AZURE_CLIENT_SECRET}.",
+      "name": "AZURE_CLIENT_SECRET",
+      "prompt": "Azure client secret",
+      "sensitive": true
+    }
+  ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
     }
   ],
   "status": "experimental",

--- a/plugins/digitalocean/manifest.json
+++ b/plugins/digitalocean/manifest.json
@@ -243,6 +243,53 @@
       "sensitive": true
     }
   ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "status": "verified",
   "tier": "community",
   "type": "external",

--- a/plugins/gcp/manifest.json
+++ b/plugins/gcp/manifest.json
@@ -34,6 +34,39 @@
     "workflowHandlers": []
   },
   "category": "infrastructure",
+  "config_targets": [
+    {
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in a local dotenv/config file for local workflows.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "description": "GCP infrastructure provider plugin for workflow — manages Cloud Run, GKE, Cloud SQL, Memorystore, VPC, Load Balancer, Cloud DNS, Artifact Registry, API Gateway, Firewall, IAM, GCS, and Certificate Manager",
   "downloads": [
     {
@@ -90,12 +123,68 @@
   "name": "workflow-plugin-gcp",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-gcp",
+  "required_config": [
+    {
+      "description": "GCP project ID for provider operations and config templates. Referenced as ${GCP_PROJECT}.",
+      "key": "project_id",
+      "name": "GCP_PROJECT",
+      "prompt": "GCP project ID",
+      "sensitive": false
+    }
+  ],
   "required_secrets": [
     {
       "description": "GCP service-account JSON key (inline blob). For the credentials.service_account_json path; ADC / Workload Identity deployments may skip. Referenced as ${GCP_SERVICE_ACCOUNT_JSON}.",
       "name": "GCP_SERVICE_ACCOUNT_JSON",
       "prompt": "GCP service-account JSON",
       "sensitive": true
+    }
+  ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
     }
   ],
   "status": "experimental",

--- a/plugins/github/manifest.json
+++ b/plugins/github/manifest.json
@@ -96,6 +96,53 @@
       "sensitive": true
     }
   ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "source": "github.com/GoCodeAlone/workflow-plugin-github",
   "status": "experimental",
   "tier": "core",

--- a/plugins/namecheap/manifest.json
+++ b/plugins/namecheap/manifest.json
@@ -16,6 +16,39 @@
     "triggerTypes": []
   },
   "category": "infrastructure",
+  "config_targets": [
+    {
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in a local dotenv/config file for local workflows.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "description": "Namecheap DNS provider for workflow IaC (infra.dns) backed by the official go-namecheap-sdk.",
   "downloads": [
     {
@@ -58,24 +91,75 @@
   "name": "workflow-plugin-namecheap",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-namecheap",
-  "required_secrets": [
+  "required_config": [
     {
-      "description": "Namecheap account username (= ApiUser per API)",
+      "description": "Namecheap account username (also the ApiUser per Namecheap API)",
+      "key": "api_user",
       "name": "NAMECHEAP_API_USER",
       "prompt": "Namecheap username",
       "sensitive": false
     },
     {
+      "description": "Non-secret public IP sent as Namecheap ClientIp on every API request; it must already be allowlisted in the Namecheap control panel.",
+      "key": "client_ip",
+      "name": "NAMECHEAP_CLIENT_IP",
+      "prompt": "Public IP already allowlisted in Namecheap (CIDR not supported)",
+      "sensitive": false
+    }
+  ],
+  "required_secrets": [
+    {
       "description": "Namecheap API key (rotate via Profile → Tools → Namecheap API Access)",
       "name": "NAMECHEAP_API_KEY",
       "prompt": "Namecheap API key",
       "sensitive": true
+    }
+  ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
     },
     {
-      "description": "Public IP of the wfctl runner — Namecheap requires single-IP allowlisting (CIDR is unsupported)",
-      "name": "NAMECHEAP_CLIENT_IP",
-      "prompt": "Public IP to whitelist",
-      "sensitive": false
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab's separate environment_scope field.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
     }
   ],
   "status": "experimental",

--- a/schema/registry-schema.json
+++ b/schema/registry-schema.json
@@ -344,6 +344,37 @@
         "additionalProperties": false
       }
     },
+    "required_config": {
+      "type": "array",
+      "description": "Non-secret configuration variables the plugin requires. Consumed by `wfctl env setup`/`wfctl vars setup` to drive provider-backed variable prompts.",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Default environment/config variable name (e.g. NAMECHEAP_API_USER)"
+          },
+          "key": {
+            "type": "string",
+            "description": "Canonical plugin config key used when a manifest maps this value to a custom stored name"
+          },
+          "sensitive": {
+            "type": "boolean",
+            "description": "Must be false for required_config; sensitive values belong in required_secrets"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description shown above the prompt"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "Optional short prompt label (defaults to name)"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "secret_targets": {
       "type": "array",
       "description": "Secret provider targets this plugin supports. Consumed by wfctl to present provider-owned scopes such as GitHub repo/org/env, GitLab project/group/env, Vault mount, or local file-backed stores.",
@@ -354,6 +385,30 @@
           "provider": {
             "type": "string",
             "description": "Canonical secret provider name (e.g. github, gitlab, vault, file, keychain, env)"
+          },
+          "scopes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Provider-owned scope identifiers supported by this target"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable target description shown by wfctl"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "config_targets": {
+      "type": "array",
+      "description": "Variable/config provider targets this plugin supports. Consumed by wfctl to present provider-owned scopes such as GitHub repo/org/env variables, GitLab project/group variables, or local file-backed stores.",
+      "items": {
+        "type": "object",
+        "required": ["provider", "scopes"],
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Canonical variable/config provider name (e.g. github, gitlab, env)"
           },
           "scopes": {
             "type": "array",

--- a/scripts/build-index.sh
+++ b/scripts/build-index.sh
@@ -77,10 +77,20 @@ while IFS= read -r manifest; do
   # G3-include: dependencies.minVersion
   # G3-include: dependencies.maxVersion
   # G3-include: required_secrets
+  # G3-include: required_config
+  # G3-include: required_config.name
+  # G3-include: required_config.key
+  # G3-include: required_config.sensitive
+  # G3-include: required_config.description
+  # G3-include: required_config.prompt
   # G3-include: secret_targets
   # G3-include: secret_targets.provider
   # G3-include: secret_targets.scopes
   # G3-include: secret_targets.description
+  # G3-include: config_targets
+  # G3-include: config_targets.provider
+  # G3-include: config_targets.scopes
+  # G3-include: config_targets.description
   # G3-include: capabilities
   # G3-include: capabilities.moduleTypes
   # G3-include: capabilities.stepTypes
@@ -201,8 +211,30 @@ while IFS= read -r manifest; do
   )
   +
   (
+    if (.required_config // null) == null then {}
+    else { required_config: [.required_config[] | {
+      name:        (.name // null),
+      key:         (.key // null),
+      sensitive:   (.sensitive // false),
+      description: (.description // null),
+      prompt:      (.prompt // null)
+    }]}
+    end
+  )
+  +
+  (
     if (.secret_targets // null) == null then {}
     else { secret_targets: [.secret_targets[] | {
+      provider:    (.provider // null),
+      scopes:      (.scopes // []),
+      description: (.description // null)
+    }]}
+    end
+  )
+  +
+  (
+    if (.config_targets // null) == null then {}
+    else { config_targets: [.config_targets[] | {
       provider:    (.provider // null),
       scopes:      (.scopes // []),
       description: (.description // null)

--- a/tests/fixtures/plugins/foo-iac/manifest.json
+++ b/tests/fixtures/plugins/foo-iac/manifest.json
@@ -51,11 +51,29 @@
     {"name": "FOO_USER", "sensitive": false, "description": "Foo username"},
     {"name": "FOO_PASS", "sensitive": true, "description": "Foo password"}
   ],
+  "required_config": [
+    {
+      "name": "FOO_ACCOUNT_ID",
+      "key": "account_id",
+      "sensitive": false,
+      "description": "Foo account identifier",
+      "prompt": "Foo account",
+      "config_leak": "should_not_appear"
+    }
+  ],
   "secret_targets": [
     {
       "provider": "github",
       "scopes": ["repo", "env"],
       "description": "Foo credentials stored in GitHub Actions secrets",
+      "target_leak": "should_not_appear"
+    }
+  ],
+  "config_targets": [
+    {
+      "provider": "github",
+      "scopes": ["repo", "env"],
+      "description": "Foo settings stored in GitHub Actions variables",
       "target_leak": "should_not_appear"
     }
   ],

--- a/tests/test-build-index.sh
+++ b/tests/test-build-index.sh
@@ -75,12 +75,20 @@ assert_jq "foo-iac iacProvider.computePlanVersion" \
   '.[] | select(.name=="foo-iac") | .iacProvider.computePlanVersion' '"v2"'
 assert_jq "foo-iac required_secrets has 2 items" \
   '.[] | select(.name=="foo-iac") | .required_secrets | length' '2'
+assert_jq "foo-iac required_config has 1 item" \
+  '.[] | select(.name=="foo-iac") | .required_config | length' '1'
 assert_jq "foo-iac secret_targets has 1 item" \
   '.[] | select(.name=="foo-iac") | .secret_targets | length' '1'
+assert_jq "foo-iac config_targets has 1 item" \
+  '.[] | select(.name=="foo-iac") | .config_targets | length' '1'
 assert_jq "foo-iac secret_targets[0].provider" \
   '.[] | select(.name=="foo-iac") | .secret_targets[0].provider' '"github"'
 assert_jq "foo-iac secret_targets[0].scopes" \
   '.[] | select(.name=="foo-iac") | .secret_targets[0].scopes' '["repo","env"]'
+assert_jq "foo-iac config_targets[0].provider" \
+  '.[] | select(.name=="foo-iac") | .config_targets[0].provider' '"github"'
+assert_jq "foo-iac config_targets[0].scopes" \
+  '.[] | select(.name=="foo-iac") | .config_targets[0].scopes' '["repo","env"]'
 
 # === Empty-array preservation ===
 assert_jq "bar-simple required_secrets preserved as []" \
@@ -99,11 +107,25 @@ fi
 if jq -e '.[] | select(.name=="qux-no-secrets") | has("secret_targets")' "${INDEX}" >/dev/null; then
   fail "qux-no-secrets should have no secret_targets key (manifest omits it)"
 fi
+if jq -e '.[] | select(.name=="qux-no-secrets") | has("required_config")' "${INDEX}" >/dev/null; then
+  fail "qux-no-secrets should have no required_config key (manifest omits it)"
+fi
+if jq -e '.[] | select(.name=="qux-no-secrets") | has("config_targets")' "${INDEX}" >/dev/null; then
+  fail "qux-no-secrets should have no config_targets key (manifest omits it)"
+fi
 
 # === required_secrets per-item allowlist (extras dropped) ===
 assert_jq "required_secrets[0] item has exactly 4 known keys" \
   '.[] | select(.name=="foo-iac") | .required_secrets[0] | keys_unsorted | sort' \
   '["description","name","prompt","sensitive"]'
+
+# === required_config per-item allowlist (extras dropped) ===
+assert_jq "required_config[0] item has exactly 5 known keys" \
+  '.[] | select(.name=="foo-iac") | .required_config[0] | keys_unsorted | sort' \
+  '["description","key","name","prompt","sensitive"]'
+if jq -e '.[] | select(.name=="foo-iac") | .required_config[0] | has("config_leak")' "${INDEX}" >/dev/null; then
+  fail "G3 allowlist regression: required_config item leaked sub-field 'config_leak'"
+fi
 
 # === secret_targets per-item allowlist (extras dropped) ===
 assert_jq "secret_targets[0] item has exactly 3 known keys" \
@@ -111,6 +133,14 @@ assert_jq "secret_targets[0] item has exactly 3 known keys" \
   '["description","provider","scopes"]'
 if jq -e '.[] | select(.name=="foo-iac") | .secret_targets[0] | has("target_leak")' "${INDEX}" >/dev/null; then
   fail "G3 allowlist regression: secret_targets item leaked sub-field 'target_leak'"
+fi
+
+# === config_targets per-item allowlist (extras dropped) ===
+assert_jq "config_targets[0] item has exactly 3 known keys" \
+  '.[] | select(.name=="foo-iac") | .config_targets[0] | keys_unsorted | sort' \
+  '["description","provider","scopes"]'
+if jq -e '.[] | select(.name=="foo-iac") | .config_targets[0] | has("target_leak")' "${INDEX}" >/dev/null; then
+  fail "G3 allowlist regression: config_targets item leaked sub-field 'target_leak'"
 fi
 
 # === Per-item allowlist on cliCommands (extras dropped) ===

--- a/tests/test-schema-allowlist-coverage.sh
+++ b/tests/test-schema-allowlist-coverage.sh
@@ -20,6 +20,8 @@
 #   - assets.* (ui, config) — added round 2 per Copilot
 #   - dependencies.items.* (name, minVersion, maxVersion) — added round 2 per Copilot
 #   - secret_targets.items.* (provider, scopes, description)
+#   - required_config.items.* (name, key, sensitive, description, prompt)
+#   - config_targets.items.* (provider, scopes, description)
 
 set -euo pipefail
 
@@ -60,7 +62,9 @@ schema_props() {
       ((.properties.iacProvider.properties // {}) | keys[] | "iacProvider." + .),
       ((.properties.assets.properties // {}) | keys[] | "assets." + .),
       ((.properties.dependencies.items.properties // {}) | keys[] | "dependencies." + .),
-      ((.properties.secret_targets.items.properties // {}) | keys[] | "secret_targets." + .)
+      ((.properties.secret_targets.items.properties // {}) | keys[] | "secret_targets." + .),
+      ((.properties.required_config.items.properties // {}) | keys[] | "required_config." + .),
+      ((.properties.config_targets.items.properties // {}) | keys[] | "config_targets." + .)
     ] | .[]
   ' "${SCHEMA}" | sort -u
 }


### PR DESCRIPTION
## Summary
- add required_config/config_targets to the registry schema and public index projection
- refresh AWS, Azure, GCP, Namecheap, DigitalOcean, and GitHub plugin manifests with released env/secret target metadata
- update registry automation to use wfctl v0.80.6 so future syncs preserve env setup metadata

## Verification
- bash scripts/validate-manifests.sh
- bash tests/test-build-index.sh
- bash tests/test-schema-allowlist-coverage.sh
- bash scripts/categorize-manifests.sh --check
- /tmp/wfctl-registry-sync-env-metadata plugin registry-sync --plugin <aws|azure|gcp|namecheap|digitalocean|github> --registry-dir .
- /tmp/wfctl-registry-sync-env-metadata plugin registry-sync readme --check --registry-dir .
- jq assertions for AWS and Namecheap required_config/config_targets in v1/index.json