### PR TITLE
chore: sync remaining plugin releases

### DIFF
--- a/plugins/cloudflare/manifest.json
+++ b/plugins/cloudflare/manifest.json
@@ -16,31 +16,64 @@
     "triggerTypes": []
   },
   "category": "infrastructure",
+  "config_targets": [
+    {
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in a local dotenv/config file for local workflows.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "description": "Cloudflare DNS provider for workflow IaC (infra.dns)",
   "downloads": [
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "7040bd30571f6ad2f58571ffc9ae06233439920f37e30d5b465d177fc601f923",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.5/workflow-plugin-cloudflare-darwin-amd64.tar.gz"
+      "sha256": "d6171601807be7850c7fa8a76a1bb9249a21e9b9474b349e88fd079c97add67e",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "d1ff593f3f7909163bfa284ea04786354cdf25218d0e584ecef2040455ef0ee0",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.5/workflow-plugin-cloudflare-darwin-arm64.tar.gz"
+      "sha256": "489eb1e314677cea6aeaeb185ce45f8be20e5ecc128a6797709899b23a7f3490",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "56323ff5150c01e3811db52e368f912115005ec99dedd96257f643f4b75b1500",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.5/workflow-plugin-cloudflare-linux-amd64.tar.gz"
+      "sha256": "32d72fd9ec941ce48e58ba8a025e6f0cd59bbe3d021fc8b554b5f1bcc64c2ffb",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "eeb981ddd929061dd97f7f99b73fba9eb683dd9d4fc8e17c46e98eb96de4d779",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.5/workflow-plugin-cloudflare-linux-arm64.tar.gz"
+      "sha256": "984cdd357a6160417943f9448b22161c5c018cf91ab9a7dc4c7f3100d2cd2f25",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-linux-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare",
@@ -58,6 +91,15 @@
   "name": "workflow-plugin-cloudflare",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare",
+  "required_config": [
+    {
+      "description": "Cloudflare account ID for zone creation and account-scoped Registrar APIs. This is non-secret provider configuration.",
+      "key": "account_id",
+      "name": "CLOUDFLARE_ACCOUNT_ID",
+      "prompt": "Cloudflare account ID",
+      "sensitive": false
+    }
+  ],
   "required_secrets": [
     {
       "description": "Cloudflare API token with Zone:Read and DNS:Edit for managed zones; registrar import/status also requires Registrar read access and auto-renew updates require Registrar edit access.",
@@ -66,8 +108,55 @@
       "sensitive": true
     }
   ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab's separate environment_scope field.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "status": "experimental",
   "tier": "community",
   "type": "external",
-  "version": "0.1.5"
+  "version": "0.1.6"
 }

--- a/plugins/hover/manifest.json
+++ b/plugins/hover/manifest.json
@@ -16,31 +16,64 @@
     "triggerTypes": []
   },
   "category": "infrastructure",
+  "config_targets": [
+    {
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in a local dotenv/config file for local workflows.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
+    }
+  ],
   "description": "Hover DNS provider for workflow IaC (infra.dns). No official API; mimics the browser-side username+password+TOTP login flow used by pjslauta/hover-dyn-dns.",
   "downloads": [
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "cbd7f72ebac3bc4c0b934bcd15645e6731fb0243114ddb9a857a7e08cff5535b",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.9/workflow-plugin-hover-darwin-amd64.tar.gz"
+      "sha256": "c186691b876c4324afccf140cd5467d5f83e77e1562860414d491c0361edcfc0",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "b904ea939dd8ac03a00a8cd4df92b4bfa6c9728e2d3373af7bd5c64650b43c39",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.9/workflow-plugin-hover-darwin-arm64.tar.gz"
+      "sha256": "28e8a405e791aca9308939f2de0226daf3b747e010787004e5a653066507e44d",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "fd53cdaad144147af9e1cb639d28ee561ab98bcbfde439a3e41780bb47f19b4d",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.9/workflow-plugin-hover-linux-amd64.tar.gz"
+      "sha256": "2bed0c3ac7567407006fb996c66021d0d436ddfe6f15731690419a424baa91e9",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "7d2a95aeb8f86caed80c3663c5341fd837e39b626870d793509251215658db7d",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.9/workflow-plugin-hover-linux-arm64.tar.gz"
+      "sha256": "a7689482f44b982f2bef41f8b1222e945b76603941cda72f1d1c331c4e84d999",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-linux-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-hover",
@@ -59,13 +92,16 @@
   "name": "workflow-plugin-hover",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-hover",
-  "required_secrets": [
+  "required_config": [
     {
-      "description": "Hover account username",
+      "description": "Hover account username or login email. This is non-secret provider configuration.",
+      "key": "username",
       "name": "HOVER_USERNAME",
       "prompt": "Hover username",
       "sensitive": false
-    },
+    }
+  ],
+  "required_secrets": [
     {
       "description": "Hover account password",
       "name": "HOVER_PASSWORD",
@@ -73,14 +109,61 @@
       "sensitive": true
     },
     {
-      "description": "Base32-encoded TOTP seed from Hover 2FA setup. Plugin generates 6-digit codes per RFC 6238 on each login.",
+      "description": "Base32-encoded TOTP seed shown when you enabled 2FA. The plugin generates 6-digit codes per RFC 6238 on each login.",
       "name": "HOVER_TOTP_SECRET",
-      "prompt": "Hover TOTP seed (base32)",
+      "prompt": "Hover TOTP seed (base32, 16+ chars)",
       "sensitive": true
+    }
+  ],
+  "secret_targets": [
+    {
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub.",
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ]
+    },
+    {
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab's separate environment_scope field.",
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ]
+    },
+    {
+      "description": "Stored in Vault for application/runtime retrieval.",
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ]
+    },
+    {
+      "description": "Stored in a local file-backed secret store.",
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ]
+    },
+    {
+      "description": "Stored in the local OS keychain.",
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ]
+    },
+    {
+      "description": "Provided by the local process environment.",
+      "provider": "env",
+      "scopes": [
+        "process"
+      ]
     }
   ],
   "status": "experimental",
   "tier": "community",
   "type": "external",
-  "version": "0.5.9"
+  "version": "0.5.10"
 }

--- a/plugins/workflow-plugin-compute/manifest.json
+++ b/plugins/workflow-plugin-compute/manifest.json
@@ -26,14 +26,14 @@
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "c9fe4ae8ec6b7cd037692da917cd10b278361d36397688d973f31170c691c3c5",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.9/workflow-plugin-compute-darwin-arm64.tar.gz"
+      "sha256": "3f2864ff3cf00846349358f676aed221503bc369773c2779211e0bc3f5ccc205",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.13/workflow-plugin-compute-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "d9bf3942cf96083c05e54623df2aa29bdd35e5bfc187fb5d490bcf4f90ab4d8e",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.9/workflow-plugin-compute-linux-amd64.tar.gz"
+      "sha256": "4d8288fc78c640bc8e8a645f138d70b32c6603f5bcbe5bba2c54170a2cb3b420",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-compute/releases/download/v0.1.13/workflow-plugin-compute-linux-amd64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-compute",
@@ -44,12 +44,12 @@
     "proof"
   ],
   "license": "MIT",
-  "minEngineVersion": "0.27.0",
+  "minEngineVersion": "0.78.2",
   "name": "workflow-plugin-compute",
   "private": false,
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-compute",
   "status": "verified",
   "tier": "community",
   "type": "external",
-  "version": "0.1.9"
+  "version": "0.1.13"
 }

--- a/plugins/workflow-plugin-product-capture/manifest.json
+++ b/plugins/workflow-plugin-product-capture/manifest.json
@@ -27,38 +27,38 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "712463e364a613964e54334971340f75be2324d81eb26f9a6aafef5347790f92",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.17/workflow-plugin-product-capture-darwin-amd64.tar.gz"
+      "sha256": "46e68b003138c0c78ed670e9e865f14cd54756ceb02ae9d927be071031d62de3",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.19/workflow-plugin-product-capture-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "04e79dc30c89664873d1fe98dc288fcaf31bc5585c385944a367bc84dfbf7090",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.17/workflow-plugin-product-capture-darwin-arm64.tar.gz"
+      "sha256": "f02f1e2aae12c80c55e865cf1cbe5fc903ae38137a2475c3bce09f98b08a17c8",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.19/workflow-plugin-product-capture-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "ce723245d688779a24045b774cfaa76c98542adaf5c96ed178f541ed604c82c1",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.17/workflow-plugin-product-capture-linux-amd64.tar.gz"
+      "sha256": "566766694a8cb5ba136bc69cf2a9dfa1c411be19b6a8ff0699c6539dc9a8ab6c",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.19/workflow-plugin-product-capture-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "f53a42bbb5c8b12d829bca3dd1618e2ffb114a5f9c1d50e373a883a056e56223",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.17/workflow-plugin-product-capture-linux-arm64.tar.gz"
+      "sha256": "1894c969788e185b34c7b57a2c6b6bd9d89094519f2ff91311756e0925e9344c",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.19/workflow-plugin-product-capture-linux-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "windows",
-      "sha256": "fbf372eb6230bb94dc363edb342e886bfafb22d4efebedac495be1236debdf47",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.17/workflow-plugin-product-capture-windows-amd64.tar.gz"
+      "sha256": "c88a234826b2f05b01ae78ad33e39e4e43b0b21bcb383cf7ac80cf173384117d",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.19/workflow-plugin-product-capture-windows-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "windows",
-      "sha256": "a0920925e11fb585da1877dde401a7d3b5847a83f46e6d18b55e8e3cf5a3fca2",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.17/workflow-plugin-product-capture-windows-arm64.tar.gz"
+      "sha256": "84ed0cb17509fcf501f115e98a7a5572c46bb00d49a306e09d6fc2d38ef1eaab",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-product-capture/releases/download/v0.1.19/workflow-plugin-product-capture-windows-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-product-capture",
@@ -76,5 +76,5 @@
   "status": "verified",
   "tier": "community",
   "type": "external",
-  "version": "0.1.17"
+  "version": "0.1.19"
 }


### PR DESCRIPTION
## Summary
- sync Cloudflare v0.1.6, Hover v0.5.10, workflow-plugin-compute v0.1.13, and workflow-plugin-product-capture v0.1.19
- preserve the new env setup metadata model from v0.80.6 registry-sync, including Cloudflare account ID and Hover username as required_config

## Verification
- bash scripts/validate-manifests.sh
- bash tests/test-build-index.sh
- bash tests/test-schema-allowlist-coverage.sh
- bash scripts/categorize-manifests.sh --check
- /tmp/wfctl-registry-sync-env-metadata plugin registry-sync --plugin <cloudflare|hover|workflow-plugin-compute|workflow-plugin-product-capture> --registry-dir .
- /tmp/wfctl-registry-sync-env-metadata plugin registry-sync readme --check --registry-dir .