### PR TITLE
Refresh provider registry manifests

### DIFF
--- a/.github/workflows/sync-registry-manifests.yml
+++ b/.github/workflows/sync-registry-manifests.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set up wfctl
         env:
-          WFCTL_VERSION: v0.80.6
+          WFCTL_VERSION: v0.80.7
         run: |
           set -euo pipefail
           install_dir="${RUNNER_TEMP}/wfctl-bin"

--- a/plugins/cloudflare/manifest.json
+++ b/plugins/cloudflare/manifest.json
@@ -5,6 +5,13 @@
   },
   "author": "GoCodeAlone",
   "capabilities": {
+    "iacProvider": {
+      "name": "cloudflare",
+      "resourceTypes": [
+        "infra.dns",
+        "infra.domain"
+      ]
+    },
     "moduleTypes": [
       "iac.provider.cloudflare"
     ],
@@ -54,26 +61,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "d6171601807be7850c7fa8a76a1bb9249a21e9b9474b349e88fd079c97add67e",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-darwin-amd64.tar.gz"
+      "sha256": "d873a8dce8573a68d0be38f8725db8b1a7a864048681e0934e4e42f155cf9882",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.7/workflow-plugin-cloudflare-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "489eb1e314677cea6aeaeb185ce45f8be20e5ecc128a6797709899b23a7f3490",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-darwin-arm64.tar.gz"
+      "sha256": "e821a4f88dbd60b6bc6d18bf88ab0bbfa8d709df8a8ae89fda5d837e0e6c0329",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.7/workflow-plugin-cloudflare-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "32d72fd9ec941ce48e58ba8a025e6f0cd59bbe3d021fc8b554b5f1bcc64c2ffb",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-linux-amd64.tar.gz"
+      "sha256": "c11cb4db8bd64bed56e8f54a44b9adf80b3c676edc47b21cef96c19d1c0aef62",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.7/workflow-plugin-cloudflare-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "984cdd357a6160417943f9448b22161c5c018cf91ab9a7dc4c7f3100d2cd2f25",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.6/workflow-plugin-cloudflare-linux-arm64.tar.gz"
+      "sha256": "12c547a9fc89c95680de1a53d308dcb7acf36b45fe41961630339c33191081bf",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare/releases/download/v0.1.7/workflow-plugin-cloudflare-linux-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-cloudflare",
@@ -158,5 +165,5 @@
   "status": "experimental",
   "tier": "community",
   "type": "external",
-  "version": "0.1.6"
+  "version": "0.1.7"
 }

--- a/plugins/hover/manifest.json
+++ b/plugins/hover/manifest.json
@@ -5,6 +5,13 @@
   },
   "author": "GoCodeAlone",
   "capabilities": {
+    "iacProvider": {
+      "name": "hover",
+      "resourceTypes": [
+        "infra.dns",
+        "infra.dns_delegation"
+      ]
+    },
     "moduleTypes": [
       "iac.provider.hover"
     ],
@@ -54,26 +61,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "c186691b876c4324afccf140cd5467d5f83e77e1562860414d491c0361edcfc0",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-darwin-amd64.tar.gz"
+      "sha256": "af235b86083659ec291a6d024584e326f225163b71f749b07228e47922ae736f",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.11/workflow-plugin-hover-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "28e8a405e791aca9308939f2de0226daf3b747e010787004e5a653066507e44d",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-darwin-arm64.tar.gz"
+      "sha256": "b4372edf8b9444c35e2ce21ad7217db6e1d48d0155f035ee4870ebfeb9bf00d6",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.11/workflow-plugin-hover-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "2bed0c3ac7567407006fb996c66021d0d436ddfe6f15731690419a424baa91e9",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-linux-amd64.tar.gz"
+      "sha256": "90a6a1f18fb76cdaf4340c8aa4471ac4fb0a2d8e139a18511834ffc626081ade",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.11/workflow-plugin-hover-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "a7689482f44b982f2bef41f8b1222e945b76603941cda72f1d1c331c4e84d999",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.10/workflow-plugin-hover-linux-arm64.tar.gz"
+      "sha256": "4345c47469a7e4fb99c1109f726a510c7d1142ee494dc59dcba52321d51fc59f",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-hover/releases/download/v0.5.11/workflow-plugin-hover-linux-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-hover",
@@ -165,5 +172,5 @@
   "status": "experimental",
   "tier": "community",
   "type": "external",
-  "version": "0.5.10"
+  "version": "0.5.11"
 }

--- a/plugins/namecheap/manifest.json
+++ b/plugins/namecheap/manifest.json
@@ -5,6 +5,13 @@
   },
   "author": "GoCodeAlone",
   "capabilities": {
+    "iacProvider": {
+      "name": "namecheap",
+      "resourceTypes": [
+        "infra.dns",
+        "infra.domain_transfer"
+      ]
+    },
     "moduleTypes": [
       "iac.provider.namecheap"
     ],
@@ -54,26 +61,26 @@
     {
       "arch": "amd64",
       "os": "darwin",
-      "sha256": "61e55045d57709c7a755568f3994a4fb157dd3e31ded29c3d11959e59d5566af",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.10/workflow-plugin-namecheap-darwin-amd64.tar.gz"
+      "sha256": "f3c18b640d2e7702db9c8532f2359389c6a6f79a88fd2a59963244a86590d31e",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.11/workflow-plugin-namecheap-darwin-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "darwin",
-      "sha256": "fd370acef20da2dc962c1f0925fa09f713c44a995a3db917b541a959b0e47592",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.10/workflow-plugin-namecheap-darwin-arm64.tar.gz"
+      "sha256": "551fbc4247110058ff08854ff837f77ae5126dfb1ad4c8ab28e2728438664048",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.11/workflow-plugin-namecheap-darwin-arm64.tar.gz"
     },
     {
       "arch": "amd64",
       "os": "linux",
-      "sha256": "38308ca3bcdfcd4a223c103f333edb938479c4311d261066d7728bc8c2986069",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.10/workflow-plugin-namecheap-linux-amd64.tar.gz"
+      "sha256": "87caab70aab56b2167cfc6e504330e09986cc07cebe21eece295c542b1c61711",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.11/workflow-plugin-namecheap-linux-amd64.tar.gz"
     },
     {
       "arch": "arm64",
       "os": "linux",
-      "sha256": "d5ead2820aa9942dfbe05e5eb786a9b87175ff265f737b89373f83dd6b4531d9",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.10/workflow-plugin-namecheap-linux-arm64.tar.gz"
+      "sha256": "c4a5b0a63be98b66ddee065f41f445bfda7f7d11b7d8dac22712f7e4841129ee",
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-namecheap/releases/download/v0.1.11/workflow-plugin-namecheap-linux-arm64.tar.gz"
     }
   ],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-namecheap",
@@ -165,5 +172,5 @@
   "status": "experimental",
   "tier": "community",
   "type": "external",
-  "version": "0.1.10"
+  "version": "0.1.11"
 }


### PR DESCRIPTION
## Summary
- sync Hover, Cloudflare, and Namecheap registry manifests to the latest released versions
- preserve nested capabilities.iacProvider metadata required by wfctl provider resolution
- update the registry sync workflow to bootstrap wfctl v0.80.7

Fixes #319

## Verification
- bash scripts/validate-manifests.sh
- bash tests/test-build-index.sh
- bash tests/test-build-versions.sh
- bash tests/test-schema-allowlist-coverage.sh
- bash tests/test-sync-workflow-token.sh